### PR TITLE
fix: apply number format to total fees in coin currency

### DIFF
--- a/app/_utils/conversions/index.ts
+++ b/app/_utils/conversions/index.ts
@@ -90,7 +90,7 @@ export const getFormattedCoinValue = ({ val, formatOptions, capAtTrillion = true
   return numbro(val)
     .format({
       ...numbroDefaultOptions,
-      thousandSeparated: true,
+      average: true,
       currencySymbol: "",
       ...formatOptions,
     })


### PR DESCRIPTION
## Reason
Replaced the `thousandSeparator` format option with `average` in the `numbro` function so that numbers can be displayed appropriately in the `K`, `M`, `B`, `T` format, as required