### PR TITLE
feat: add rewards history page

### DIFF
--- a/app/(root)/_components/NavCard/index.tsx
+++ b/app/(root)/_components/NavCard/index.tsx
@@ -6,10 +6,6 @@ import { Icon } from "../../../_components/Icon";
 import { getLinkWithSearchParams } from "../../../_utils/routes";
 import * as S from "./navCard.css";
 
-export const Rewards = (props: PageNavCardProps) => {
-  return <Card {...props} page="rewards" />;
-};
-
 export const PrimaryText = ({ children }: { children: ReactNode }) => {
   return <span className={cn(S.primaryText)}>{children}</span>;
 };

--- a/app/(root)/_components/RewardsNavCard.tsx
+++ b/app/(root)/_components/RewardsNavCard.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useWallet } from "../../_contexts/WalletContext";
+import * as NavCard from "../_components/NavCard";
+
+export const RewardsNavCard = (props: NavCard.PageNavCardProps) => {
+  const { connectionStatus } = useWallet();
+  const isDisabled = connectionStatus !== "connected";
+
+  return (
+    <NavCard.Card
+      {...props}
+      page="rewards"
+      disabled={isDisabled}
+      endBox={{
+        title: <NavCard.SecondaryText>Rewards</NavCard.SecondaryText>,
+        value: <NavCard.PrimaryText>00.00 %</NavCard.PrimaryText>,
+      }}
+    />
+  );
+};

--- a/app/(root)/_components/RewardsTooltip/index.tsx
+++ b/app/(root)/_components/RewardsTooltip/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useDynamicAssetValueFromCoin } from "../../../_utils/conversions/hooks";
+import Tooltip from "@/app/_components/Tooltip";
+import { Icon } from "@/app/_components/Icon";
+import * as S from "./rewardsTooltip.css";
+
+export const RewardsTooltip = () => {
+  const formattedDailyReward = useDynamicAssetValueFromCoin({ coinVal: 1 });
+  const formattedMonthlyReward = useDynamicAssetValueFromCoin({ coinVal: 10 });
+  const formattedYearlyReward = useDynamicAssetValueFromCoin({ coinVal: 100 });
+
+  return (
+    <Tooltip
+      className={S.rewardsTooltip}
+      variant="multilines"
+      trigger={<Icon name="info" />}
+      title="Estimated rewards"
+      content={
+        <ul className={S.rewardsList}>
+          <li className={S.rewardsItem}>
+            <span className={S.rewardsInterval}>Daily</span>
+            <span className={S.rewardsValue}>{formattedDailyReward}</span>
+          </li>
+          <li className={S.rewardsItem}>
+            <span className={S.rewardsInterval}>Monthly</span>
+            <span className={S.rewardsValue}>{formattedMonthlyReward}</span>
+          </li>
+          <li className={S.rewardsItem}>
+            <span className={S.rewardsInterval}>Yearly</span>
+            <span className={S.rewardsValue}>{formattedYearlyReward}</span>
+          </li>
+        </ul>
+      }
+    />
+  );
+};

--- a/app/(root)/_components/RewardsTooltip/rewardsTooltip.css.ts
+++ b/app/(root)/_components/RewardsTooltip/rewardsTooltip.css.ts
@@ -1,0 +1,42 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+import { colors, weights } from "../../../../theme/theme.css";
+import { pxToRem } from "@/theme/utils";
+
+export const rewardsTooltip = style({
+  inlineSize: pxToRem(200),
+});
+
+export const rewardsList = style({});
+
+globalStyle(`${rewardsList} > * + *`, {
+  marginBlockStart: pxToRem(12),
+});
+
+export const rewardsItem = style({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  lineHeight: 1,
+});
+
+export const rewardsInterval = style({
+  fontWeight: weights.bold,
+  display: "flex",
+  alignItems: "center",
+
+  selectors: {
+    "&::before": {
+      content: "",
+      inlineSize: "4px",
+      blockSize: "4px",
+      borderRadius: "50%",
+      backgroundColor: colors.black600,
+      marginInlineEnd: pxToRem(8),
+    },
+  },
+});
+
+export const rewardsValue = style({
+  fontWeight: weights.regular,
+  color: colors.black300,
+});

--- a/app/(root)/_components/StakeNavCard.tsx
+++ b/app/(root)/_components/StakeNavCard.tsx
@@ -1,39 +1,15 @@
 "use client";
-import { useMemo } from "react";
-import BigNumber from "bignumber.js";
 import { useShell } from "../../_contexts/ShellContext";
 import { useWallet } from "../../_contexts/WalletContext";
 import { useWalletBalance } from "../../_services/wallet/hooks";
-import {
-  getFormattedUSDPriceFromCoin,
-  getFormattedEURPriceFromCoin,
-  getFormattedCoinValue,
-} from "../../_utils/conversions";
+import { useDynamicAssetValueFromCoin } from "../../_utils/conversions/hooks";
 import * as NavCard from "../_components/NavCard";
 
 export const StakeNavCard = (props: NavCard.PageNavCardProps) => {
   const { address, activeWallet } = useWallet();
-  const { network, currency, coinPrice } = useShell();
+  const { network } = useShell();
   const { data: balanceData } = useWalletBalance({ address, network, activeWallet }) || {};
-
-  const balance = useMemo(() => {
-    if (!balanceData) return undefined;
-    const castedCurrency = currency || "USD";
-
-    if (castedCurrency === "USD") {
-      return getFormattedUSDPriceFromCoin({
-        val: balanceData,
-        price: coinPrice?.[network || "celestia"]?.USD || 0,
-      });
-    }
-    if (castedCurrency === "EUR") {
-      return getFormattedEURPriceFromCoin({
-        val: balanceData,
-        price: coinPrice?.[network || "celestia"]?.EUR || 0,
-      });
-    }
-    return getFormattedCoinValue({ val: BigNumber(balanceData).toNumber() });
-  }, [balanceData, coinPrice, currency, network]);
+  const balance = useDynamicAssetValueFromCoin({ coinVal: balanceData });
 
   return (
     <NavCard.Card

--- a/app/(root)/_components/UnstakeNavCard.tsx
+++ b/app/(root)/_components/UnstakeNavCard.tsx
@@ -4,13 +4,18 @@ import { useWallet } from "../../_contexts/WalletContext";
 import { useUnbondingDelegations, useStakedBalance } from "../../_services/stakingOperator/hooks";
 import * as NavCard from "../_components/NavCard";
 import { Skeleton } from "../../_components/Skeleton";
+import { getTimeUnitStrings } from "../../_utils/time";
 
 export const UnstakeNavCard = (props: NavCard.PageNavCardProps) => {
   const { connectionStatus } = useWallet();
   const { stakedBalance } = useStakedBalance() || {};
   const unbondingDelegations = useUnbondingDelegations();
 
-  const isDisabled = connectionStatus !== "connected" || !stakedBalance || stakedBalance === "0";
+  const isDisabled =
+    connectionStatus !== "connected" ||
+    !!unbondingDelegations?.error ||
+    unbondingDelegations?.isLoading ||
+    stakedBalance === "0";
 
   const endBoxValue = useMemo(() => {
     if (connectionStatus !== "connected") return undefined;
@@ -30,12 +35,15 @@ export const UnstakeNavCard = (props: NavCard.PageNavCardProps) => {
       };
     }
     if (unbondingDelegations?.formatted?.length) {
+      const times =
+        unbondingDelegations.formatted[0].remainingTime &&
+        getTimeUnitStrings(unbondingDelegations.formatted[0].remainingTime);
+
       return {
         title: <NavCard.SecondaryText>In progress {unbondingDelegations.formatted.length}</NavCard.SecondaryText>,
         value: (
           <NavCard.PrimaryText>
-            {unbondingDelegations.formatted[0].remainingDays}
-            <NavCard.SecondaryText> days left</NavCard.SecondaryText>
+            {times?.time} <NavCard.SecondaryText>{times?.unit} left</NavCard.SecondaryText>
           </NavCard.PrimaryText>
         ),
       };

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -6,9 +6,9 @@ import { getDynamicPageMetadata } from "../_utils/site";
 import revalidatePageQueries from "../_actions/revalidatePageQueries";
 import { DefaultViewTop } from "./_components/WidgetTop";
 import { HeroCard } from "./_components/HeroCard";
-import * as NavCard from "./_components/NavCard";
 import { StakeNavCard } from "./_components/StakeNavCard";
 import { UnstakeNavCard } from "./_components/UnstakeNavCard";
+import { RewardsNavCard } from "./_components/RewardsNavCard";
 import { ActivityNavCard } from "./_components/ActivityNavCard";
 import * as S from "./root.css";
 
@@ -24,14 +24,7 @@ export default async function Home({ searchParams }: RouterStruct) {
       <nav className={cn(S.nav)}>
         <StakeNavCard searchParams={searchParams} />
         <UnstakeNavCard searchParams={searchParams} />
-        <NavCard.Rewards
-          searchParams={searchParams}
-          disabled
-          endBox={{
-            title: <NavCard.SecondaryText>Rewards</NavCard.SecondaryText>,
-            value: <NavCard.PrimaryText>00.00 %</NavCard.PrimaryText>,
-          }}
-        />
+        <RewardsNavCard searchParams={searchParams} />
         <ActivityNavCard searchParams={searchParams} />
       </nav>
     </>

--- a/app/(root)/rewards/_components/HistoryTable/historyTable.css.ts
+++ b/app/(root)/rewards/_components/HistoryTable/historyTable.css.ts
@@ -1,0 +1,5 @@
+import { style } from "@vanilla-extract/css";
+
+export const errorPad = style({
+  blockSize: "100%",
+});

--- a/app/(root)/rewards/_components/HistoryTable/index.tsx
+++ b/app/(root)/rewards/_components/HistoryTable/index.tsx
@@ -1,0 +1,88 @@
+"use client";
+import type { Network } from "../../../../types";
+import type { RewardsHistoryItem } from "../../../../_services/stakingOperator/types";
+import { useShell } from "../../../../_contexts/ShellContext";
+import { Skeleton } from "../../../../_components/Skeleton";
+import * as ListTable from "../../../../_components/ListTable";
+import { ErrorRetryModule } from "../../../../_components/ErrorRetryModule";
+import { getPercentagedNumber } from "../../../../_utils/number";
+import { getUTCStringFromUnixTimestamp } from "../../../../_utils/time";
+import { useDynamicAssetValueFromCoin } from "../../../../_utils/conversions/hooks";
+import { useRewardsHistory } from "../../../../_services/stakingOperator/hooks";
+import { networkExplorer } from "../../../../consts";
+import * as S from "./historyTable.css";
+
+export const RewardsHistoryTable = () => {
+  const { network } = useShell();
+  const { params, query } = useRewardsHistory() || {};
+  const { offset, setOffset, limit } = params;
+  const { data, isFetching, error, disableNextPage, lastOffset, refetch } = query || {};
+
+  if (isFetching) {
+    return (
+      <>
+        <Skeleton width="100%" height={26} />
+        <ListTable.Pad>
+          {[...Array(limit)].map((_, index) => (
+            <Skeleton key={`rewards-history-skeleton-${index}`} width="100%" height={36} />
+          ))}
+          <Skeleton width={100} height={18} />
+        </ListTable.Pad>
+      </>
+    );
+  }
+
+  if (error) {
+    return (
+      <ListTable.Pad className={S.errorPad}>
+        <ErrorRetryModule onRetry={refetch} isLoading={isFetching} />
+      </ListTable.Pad>
+    );
+  }
+
+  return (
+    <>
+      <ListTable.Pad>
+        <ListTable.List>
+          {data?.map((rewardsHistory, index) => (
+            <ListItem key={index + rewardsHistory.txHash} rewardsHistory={rewardsHistory} network={network} />
+          ))}
+        </ListTable.List>
+        <ListTable.Pagination
+          currentPage={offset + 1}
+          hasNextPage={!disableNextPage}
+          onNextClick={() => setOffset(offset + 1)}
+          onPrevClick={() => setOffset(offset - 1)}
+          onFirstClick={() => setOffset(0)}
+          onLastClick={() => lastOffset && setOffset(lastOffset)}
+        />
+      </ListTable.Pad>
+    </>
+  );
+};
+
+const ListItem = ({ rewardsHistory, network }: { rewardsHistory: RewardsHistoryItem; network: Network | null }) => {
+  const amount = useDynamicAssetValueFromCoin({ coinVal: rewardsHistory.amount });
+
+  return (
+    <ListTable.Item>
+      <ListTable.ExternalLinkItemWrapper href={`${networkExplorer[network || "celestia"]}tx/${rewardsHistory.txHash}`}>
+        <ListTable.TxInfoPrimary
+          title={titleKey[rewardsHistory.type]}
+          externalLink={!!rewardsHistory.txHash}
+          amount={amount || "－"}
+          isProcessing={rewardsHistory.inProgress}
+        />
+        <ListTable.TxInfoSecondary
+          time={getUTCStringFromUnixTimestamp(rewardsHistory.timestamp)}
+          reward={`Reward ${getPercentagedNumber(rewardsHistory.rewardRate)}`}
+          isProcessing={rewardsHistory.inProgress}
+        />
+      </ListTable.ExternalLinkItemWrapper>
+    </ListTable.Item>
+  );
+};
+
+const titleKey = {
+  compound: "Compound",
+};

--- a/app/(root)/rewards/_components/RewardsSummary/index.tsx
+++ b/app/(root)/rewards/_components/RewardsSummary/index.tsx
@@ -1,0 +1,65 @@
+"use client";
+import cn from "classnames";
+import { fromUnixTime } from "date-fns";
+import { useShell } from "../../../../_contexts/ShellContext";
+import { Icon } from "../../../../_components/Icon";
+import * as InfoCard from "../../../../_components/InfoCard";
+import { LinkCTAButton } from "../../../../_components/CTAButton";
+import { RewardsTooltip } from "../../../_components/RewardsTooltip";
+import { rewardsFrequencyByNetwork } from "../../../../consts";
+import { getTimeDiffInSingleString } from "../../../../_utils/time";
+import { useLinkWithSearchParams } from "../../../../_utils/routes";
+import { useDynamicAssetValueFromCoin } from "../../../../_utils/conversions/hooks";
+import * as S from "./rewardsSummary.css";
+
+export const RewardsSummary = () => {
+  const { network } = useShell();
+  const historyLink = useLinkWithSearchParams("rewards/history");
+  const formattedCumulative = useDynamicAssetValueFromCoin({ coinVal: 205.72 });
+  const formattedCycleReward = useDynamicAssetValueFromCoin({ coinVal: 0.015041 });
+  const formattedNextCompounding = getTimeDiffInSingleString(fromUnixTime(1745099829));
+
+  return (
+    <>
+      <section className={cn(S.card)}>
+        <h3 className={cn(S.cardTitle)}>Cumulative</h3>
+        <p className={cn(S.cardValue)}>{formattedCumulative}</p>
+      </section>
+      <section className={cn(S.card)}>
+        <h3 className={cn(S.cardTitle)}>Rewards from this cycle</h3>
+        <p className={cn(S.cardValue)}>{formattedCycleReward}</p>
+      </section>
+      <InfoCard.Card>
+        <InfoCard.Stack>
+          <InfoCard.StackItem>
+            <InfoCard.TitleBox>
+              <InfoCard.Title>Next compounding</InfoCard.Title>
+            </InfoCard.TitleBox>
+            <InfoCard.Content>{formattedNextCompounding} left</InfoCard.Content>
+          </InfoCard.StackItem>
+          <InfoCard.StackItem>
+            <InfoCard.TitleBox>
+              <InfoCard.Title>Reward</InfoCard.Title>
+              <RewardsTooltip />
+            </InfoCard.TitleBox>
+            <InfoCard.Content className={S.rewardInfoValue}>00.00%</InfoCard.Content>
+          </InfoCard.StackItem>
+          <InfoCard.StackItem>
+            <InfoCard.TitleBox>
+              <InfoCard.Title>Reward frequency</InfoCard.Title>
+            </InfoCard.TitleBox>
+            <InfoCard.Content>{rewardsFrequencyByNetwork[network || "celestia"]}</InfoCard.Content>
+          </InfoCard.StackItem>
+        </InfoCard.Stack>
+      </InfoCard.Card>
+      {/* TODO: update URL */}
+      <a className={S.link} href="#" target="_blank" rel="noopener noreferrer">
+        <span>More info about compounding</span>
+        <Icon name="arrow" size={12} />
+      </a>
+      <LinkCTAButton className={S.ctaButton} variant="secondary" href={historyLink}>
+        View history
+      </LinkCTAButton>
+    </>
+  );
+};

--- a/app/(root)/rewards/_components/RewardsSummary/rewardsSummary.css.ts
+++ b/app/(root)/rewards/_components/RewardsSummary/rewardsSummary.css.ts
@@ -1,0 +1,55 @@
+import { style } from "@vanilla-extract/css";
+import { pxToRem } from "../../../../../theme/utils";
+import { colors } from "../../../../../theme/theme.css";
+
+export const card = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: pxToRem(10),
+  backgroundColor: colors.black700,
+  border: `1px solid ${colors.black800}`,
+  borderRadius: pxToRem(8),
+  paddingInline: pxToRem(20),
+  paddingBlockStart: pxToRem(16),
+  paddingBlockEnd: pxToRem(20),
+});
+
+export const cardTitle = style({
+  textAlign: "center",
+  fontSize: pxToRem(12),
+  lineHeight: 1,
+  color: colors.black300,
+});
+
+export const cardValue = style({
+  textAlign: "center",
+  fontSize: pxToRem(24),
+  lineHeight: 1,
+  color: colors.black000,
+});
+
+export const rewardInfoValue = style({
+  color: colors.green900,
+});
+
+export const link = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: pxToRem(4),
+  fontSize: pxToRem(14),
+  lineHeight: 1,
+  color: colors.black600,
+
+  selectors: {
+    "&:hover": {
+      color: colors.black300,
+    },
+  },
+});
+
+export const ctaButton = style({
+  marginBlockStart: "auto",
+});

--- a/app/(root)/rewards/history/page.tsx
+++ b/app/(root)/rewards/history/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import type { RouterStruct } from "../../../types";
+import { PageViewTop } from "../../_components/WidgetTop";
+import redirectPage from "../../../_actions/redirectPage";
+import revalidatePageQueries from "../../../_actions/revalidatePageQueries";
+import { getDynamicPageMetadata } from "../../../_utils/site";
+import { getLinkWithSearchParams } from "../../../_utils/routes";
+import { RewardsHistoryTable } from "../_components/HistoryTable";
+
+export default async function Rewards({ searchParams }: RouterStruct) {
+  const { network } = searchParams || {};
+  await redirectPage(searchParams, "rewards/history");
+  await revalidatePageQueries(network);
+
+  return (
+    <>
+      <PageViewTop page="Rewards history" homeURL={getLinkWithSearchParams(searchParams, "rewards")} />
+      <RewardsHistoryTable />
+    </>
+  );
+}
+
+export async function generateMetadata({ searchParams }: RouterStruct): Promise<Metadata> {
+  return getDynamicPageMetadata({ page: "Rewards history", networkParam: searchParams?.network });
+}

--- a/app/(root)/rewards/page.tsx
+++ b/app/(root)/rewards/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import type { RouterStruct } from "../../types";
-import Link from "next/link";
+import { PageViewTop } from "../_components/WidgetTop";
 import redirectPage from "../../_actions/redirectPage";
 import revalidatePageQueries from "../../_actions/revalidatePageQueries";
 import { getDynamicPageMetadata } from "../../_utils/site";
 import { getLinkWithSearchParams } from "../../_utils/routes";
+import { RewardsSummary } from "./_components/RewardsSummary";
 
 export default async function Rewards({ searchParams }: RouterStruct) {
   const { network } = searchParams || {};
@@ -12,13 +13,10 @@ export default async function Rewards({ searchParams }: RouterStruct) {
   await revalidatePageQueries(network);
 
   return (
-    <div style={{ marginTop: "5rem" }}>
-      <h1>Rewards view</h1>
-
-      <nav style={{ marginTop: "5rem" }}>
-        <Link href={getLinkWithSearchParams(searchParams, "")}>Back to home</Link>
-      </nav>
-    </div>
+    <>
+      <PageViewTop page="Rewards" homeURL={getLinkWithSearchParams(searchParams, "")} />
+      <RewardsSummary />
+    </>
   );
 }
 

--- a/app/(root)/stake/_components/StakeInfoBox.tsx
+++ b/app/(root)/stake/_components/StakeInfoBox.tsx
@@ -1,42 +1,18 @@
 "use client";
-import BigNumber from "bignumber.js";
 import { useShell } from "../../../_contexts/ShellContext";
 import { useStaking } from "../../../_contexts/StakingContext";
 import * as InfoCard from "../../../_components/InfoCard";
-import {
-  getFormattedUSDPriceFromCoin,
-  getFormattedEURPriceFromCoin,
-  getFormattedCoinValue,
-} from "../../../_utils/conversions";
+import { useDynamicAssetValueFromCoin } from "../../../_utils/conversions/hooks";
 import { feeRatioByNetwork, unstakingPeriodByNetwork } from "../../../consts";
 import Tooltip from "@/app/_components/Tooltip";
 import { Icon } from "@/app/_components/Icon";
-
+import { RewardsTooltip } from "../../_components/RewardsTooltip";
 import * as S from "./stake.css";
 
 export const StakeInfoBox = () => {
-  const { currency, coinPrice, network } = useShell();
+  const { network } = useShell();
   const { stakeFees } = useStaking();
-
-  const formatCoinValue = (val: string | number) => {
-    const castedCurrency = currency || "USD";
-
-    if (castedCurrency === "USD") {
-      return getFormattedUSDPriceFromCoin({
-        val,
-        price: coinPrice?.[network || "celestia"]?.USD || 0,
-      });
-    }
-
-    if (castedCurrency === "EUR") {
-      return getFormattedEURPriceFromCoin({
-        val,
-        price: coinPrice?.[network || "celestia"]?.EUR || 0,
-      });
-    }
-
-    return getFormattedCoinValue({ val: BigNumber(val).toNumber() });
-  };
+  const formattedStakeFees = useDynamicAssetValueFromCoin({ coinVal: stakeFees });
 
   const unstakingPeriod = unstakingPeriodByNetwork[network || "celestia"];
   const platformFee = feeRatioByNetwork[network || "celestia"] * 100;
@@ -47,29 +23,7 @@ export const StakeInfoBox = () => {
         <InfoCard.StackItem>
           <InfoCard.TitleBox>
             <InfoCard.Title>Reward</InfoCard.Title>
-
-            <Tooltip
-              className={S.rewardsTooltip}
-              variant="multilines"
-              trigger={<Icon name="info" />}
-              title="Estimated rewards"
-              content={
-                <ul className={S.rewardsList}>
-                  <li className={S.rewardsItem}>
-                    <span className={S.rewardsInterval}>Daily</span>
-                    <span className={S.rewardsValue}>{formatCoinValue(1)}</span>
-                  </li>
-                  <li className={S.rewardsItem}>
-                    <span className={S.rewardsInterval}>Monthly</span>
-                    <span className={S.rewardsValue}>{formatCoinValue(10)}</span>
-                  </li>
-                  <li className={S.rewardsItem}>
-                    <span className={S.rewardsInterval}>Yearly</span>
-                    <span className={S.rewardsValue}>{formatCoinValue(100)}</span>
-                  </li>
-                </ul>
-              }
-            />
+            <RewardsTooltip />
           </InfoCard.TitleBox>
           <InfoCard.Content className={S.rewardInfoValue}>00.00%</InfoCard.Content>
         </InfoCard.StackItem>
@@ -87,7 +41,7 @@ export const StakeInfoBox = () => {
                 }
               />
             </InfoCard.TitleBox>
-            <InfoCard.Content>{formatCoinValue(stakeFees)}</InfoCard.Content>
+            <InfoCard.Content>{formattedStakeFees}</InfoCard.Content>
           </InfoCard.StackItem>
         )}
         {stakeFees && (

--- a/app/(root)/stake/_components/stake.css.ts
+++ b/app/(root)/stake/_components/stake.css.ts
@@ -14,45 +14,6 @@ export const rewardInfoValue = style({
   color: colors.green900,
 });
 
-export const rewardsTooltip = style({
-  inlineSize: pxToRem(200),
-});
-
-export const rewardsList = style({});
-
-globalStyle(`${rewardsList} > * + *`, {
-  marginBlockStart: pxToRem(12),
-});
-
-export const rewardsItem = style({
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  lineHeight: 1,
-});
-
-export const rewardsInterval = style({
-  fontWeight: weights.bold,
-  display: "flex",
-  alignItems: "center",
-
-  selectors: {
-    "&::before": {
-      content: "",
-      inlineSize: "4px",
-      blockSize: "4px",
-      borderRadius: "50%",
-      backgroundColor: colors.black600,
-      marginInlineEnd: pxToRem(8),
-    },
-  },
-});
-
-export const rewardsValue = style({
-  fontWeight: weights.regular,
-  color: colors.black300,
-});
-
 export const plusSign = style({
   color: colors.black300,
 });

--- a/app/_components/CTAButton/index.tsx
+++ b/app/_components/CTAButton/index.tsx
@@ -1,16 +1,28 @@
-import type { ButtonHTMLAttributes } from "react";
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from "react";
+import type { LinkProps } from "next/link";
 import type { ButtonVariants } from "./ctaButton.css";
+import Link from "next/link";
 import cn from "classnames";
 import { button } from "./ctaButton.css";
 import { LoadingSpinner } from "../LoadingSpinner";
 
-export type CTAButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & ButtonVariants & {};
+export type CTAButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & ButtonVariants;
 
 export const CTAButton = ({ variant, state, className, children, ...props }: CTAButtonProps) => {
   return (
     <button className={cn(button({ variant, state }), className)} {...props}>
       {children}
     </button>
+  );
+};
+
+export type LinkCTAButtonProps = AnchorHTMLAttributes<HTMLAnchorElement> & ButtonVariants & LinkProps;
+
+export const LinkCTAButton = ({ variant, state, className, children, href, ...props }: LinkCTAButtonProps) => {
+  return (
+    <Link href={href} className={cn(button({ variant, state }), className)} {...props}>
+      {children}
+    </Link>
   );
 };
 

--- a/app/_services/stakingOperator/celestia/index.ts
+++ b/app/_services/stakingOperator/celestia/index.ts
@@ -56,6 +56,25 @@ export const getAddressActivity = ({
   } as T.AddressActivityResponse;
 };
 
+export const getAddressRewardsHistory = ({
+  address,
+  offset,
+  limit,
+}: T.AddressRewardsHistoryPaginationParams & { address: string }) => {
+  return {
+    status: "OK",
+    statusCode: 200,
+    totalEntries: 100,
+    data: new Array(limit).fill(0).map(() => ({
+      type: "compound",
+      amount: Math.floor(Math.random() * 100),
+      rewardRate: Math.random() * 0.1,
+      timestamp: Math.floor(Math.random() * 100000),
+      txHash: Math.random().toString(36).substring(7),
+    })),
+  } as T.AddressRewardsHistoryResponse;
+};
+
 export const getDelegateMessage = async (address: string, amount: number) => {
   const res: T.DelegateMessageResponse = await fetchData(`${API_URL}stake/user/delegate`, {
     method: "POST",

--- a/app/_services/stakingOperator/hooks.tsx
+++ b/app/_services/stakingOperator/hooks.tsx
@@ -6,6 +6,7 @@ import {
   useCelestiaDelegations,
   useCelestiaUnbondingDelegations,
   useAddressActivity,
+  useAddressRewardsHistory,
 } from "../stakingOperator/celestia/hooks";
 
 export const useUnbondingDelegations = () => {
@@ -87,4 +88,49 @@ export const useLastOffsetActivity = ({ offset, limit, filterKey }: T.AddressAct
   const { lastOffset } = useAddressActivity({ address: address || undefined, offset, limit, filterKey });
 
   return useAddressActivity({ address: address || undefined, offset: lastOffset, limit, filterKey });
+};
+
+export const useAddressRewardsHistoryQueryParams = () => {
+  const [offset, setOffset] = useState(0);
+  const [limit, setLimit] = useState(6);
+
+  return {
+    offset,
+    setOffset,
+    limit,
+    setLimit,
+  };
+};
+
+export const useRewardsHistory = () => {
+  const { network } = useShell();
+  const { address } = useWallet();
+
+  const { offset, setOffset, limit } = useAddressRewardsHistoryQueryParams();
+  const celestia = useAddressRewardsHistory({
+    address: address && (network === "celestia" || network === "celestiatestnet3") ? address : undefined,
+    offset,
+    limit,
+  });
+
+  switch (network) {
+    case "celestia":
+    case "celestiatestnet3":
+      return {
+        params: { offset, setOffset, limit },
+        query: celestia,
+      };
+    default:
+      return {
+        params: { offset, setOffset, limit },
+        query: undefined,
+      };
+  }
+};
+
+export const useLastOffsetRewardsHistory = ({ offset, limit }: T.AddressRewardsHistoryPaginationParams) => {
+  const { address } = useWallet();
+  const { lastOffset } = useAddressRewardsHistory({ address: address || undefined, offset, limit });
+
+  return useAddressRewardsHistory({ address: address || undefined, offset: lastOffset, limit });
 };

--- a/app/_services/stakingOperator/types.ts
+++ b/app/_services/stakingOperator/types.ts
@@ -148,6 +148,24 @@ export type ActivityItem = {
   inProgress?: boolean;
 };
 
+export type AddressRewardsHistoryResponse = CommonEntriesResponse<
+  AddressRewardsHistoryPaginationParams & { address: string },
+  RewardsHistoryItem
+> & {
+  hasMore?: boolean | null;
+  totalEntries?: number | null;
+};
+export type AddressRewardsHistoryPaginationParams = PaginationParams;
+
+export type RewardsHistoryItem = {
+  type: "compound";
+  amount: number;
+  rewardRate: number;
+  timestamp: number;
+  txHash: string;
+  inProgress?: boolean;
+};
+
 export type PaginationParams = {
   offset: number;
   limit: number;

--- a/app/_services/unstake/types.ts
+++ b/app/_services/unstake/types.ts
@@ -17,6 +17,11 @@ export type UnstakeProcedureState = "idle" | "active" | "loading" | "success" | 
 
 export type UnbondingDelegation = {
   validatorAddress: string;
-  remainingDays: number;
+  remainingTime?: {
+    d: number | undefined;
+    h: number | undefined;
+    m: number | undefined;
+    s: number | undefined;
+  };
   amount: string;
 };

--- a/app/_utils/conversions/hooks.tsx
+++ b/app/_utils/conversions/hooks.tsx
@@ -1,7 +1,17 @@
 import BigNumber from "bignumber.js";
 import { useShell } from "../../_contexts/ShellContext";
 import { networkCurrency } from "../../consts";
-import { getFormattedCoinValue, getFormattedUSDPriceFromCoin, getFormattedEURPriceFromCoin } from ".";
+import {
+  getFormattedCoinValue,
+  getFormattedUSDPriceFromCoin,
+  getFormattedEURPriceFromCoin,
+  getDynamicAssetValueFromCoin,
+} from ".";
+
+export const useDynamicAssetValueFromCoin = ({ coinVal }: { coinVal?: string | number }) => {
+  const { currency, coinPrice, network } = useShell();
+  return getDynamicAssetValueFromCoin({ coinVal, currency, coinPrice, network });
+};
 
 export const useFormattedNetworkValue = ({ val }: { val?: string | number }) => {
   const { network, currency, coinPrice } = useShell();

--- a/app/_utils/conversions/index.ts
+++ b/app/_utils/conversions/index.ts
@@ -1,4 +1,4 @@
-import type { FiatCurrency } from "../../types";
+import type { FiatCurrency, CoinPrice, Currency, Network } from "../../types";
 import BigNumber from "bignumber.js";
 import numbro from "numbro";
 import { fiatCurrencyMap } from "../../consts";
@@ -7,6 +7,38 @@ const numbroDefaultOptions: numbro.Format = {
   mantissa: 2,
 };
 numbroDefaultOptions.roundingFunction = Math.floor;
+
+export const getDynamicAssetValueFromCoin = ({
+  network,
+  coinVal,
+  coinPrice,
+  currency,
+}: {
+  network: Network | null;
+  coinVal?: string | number;
+  coinPrice: CoinPrice | null;
+  currency: Currency | null;
+}) => {
+  const castedCurrency = currency || "USD";
+
+  if (!coinVal) return undefined;
+
+  if (castedCurrency === "USD") {
+    return getFormattedUSDPriceFromCoin({
+      val: coinVal,
+      price: coinPrice?.[network || "celestia"]?.USD || 0,
+    });
+  }
+
+  if (castedCurrency === "EUR") {
+    return getFormattedEURPriceFromCoin({
+      val: coinVal,
+      price: coinPrice?.[network || "celestia"]?.EUR || 0,
+    });
+  }
+
+  return getFormattedCoinValue({ val: BigNumber(coinVal).toNumber() });
+};
 
 export const getFormattedUSDPriceFromCoin = ({ val, price, options }: Omit<GetPriceProps, "currency">) => {
   const value = getFiatPriceFromCoin({ val, price });

--- a/app/_utils/time.ts
+++ b/app/_utils/time.ts
@@ -1,4 +1,83 @@
+import moment from "moment";
 import { fromUnixTime } from "date-fns";
+
+export const getTimeDiffInSingleString = (time?: string | Date) => {
+  if (!time) return undefined;
+  const diff = getTimeDiffFromNow(time);
+
+  if (diff.asMinutes() <= 1) {
+    return `${diff.seconds()}s`;
+  } else if (diff.asHours() <= 1) {
+    return `${diff.minutes()}m`;
+  } else if (diff.asHours() <= 24) {
+    let result = `${Math.floor(diff.asHours())}h`;
+    if (diff.minutes() > 0) {
+      result += ` ${diff.minutes()}m`;
+    }
+    return result;
+  } else {
+    return `${diff.days()}d`;
+  }
+};
+
+export const getTimeDiffInSingleUnits = (time?: string | Date) => {
+  if (!time) return undefined;
+  const diff = getTimeDiffFromNow(time);
+
+  const units: TimeUnits = {
+    d: undefined,
+    h: undefined,
+    m: undefined,
+    s: undefined,
+  };
+
+  if (diff.asMinutes() <= 1) {
+    units.s = Math.floor(diff.seconds());
+  } else if (diff.asHours() <= 1) {
+    units.m = Math.floor(diff.minutes());
+  } else if (diff.asHours() <= 24) {
+    units.h = Math.floor(diff.hours());
+  } else {
+    units.d = Math.floor(diff.asDays());
+  }
+
+  return units;
+};
+
+export const getTimeUnitStrings = (units: TimeUnits) => {
+  if (units.d !== undefined) {
+    return {
+      time: units.d,
+      unit: "days",
+    };
+  }
+  if (units.h !== undefined) {
+    return {
+      time: units.h,
+      unit: "hrs",
+    };
+  }
+  if (units.m !== undefined) {
+    return {
+      time: units.m,
+      unit: "mins",
+    };
+  }
+  if (units.s !== undefined) {
+    return {
+      time: units.s,
+      unit: "secs",
+    };
+  }
+};
+
+const getTimeDiffFromNow = (time: string | Date) => {
+  const now = moment();
+  const endTime = moment(time);
+  const diff = moment.duration(endTime.diff(now));
+
+  return diff;
+};
 
 export const getFormattedUTCString = (date: Date) => {
   const year = date.getUTCFullYear();
@@ -16,3 +95,10 @@ export const getUTCStringFromUnixTimestamp = (timestamp: number) => {
 };
 
 const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+type TimeUnits = {
+  d: number | undefined;
+  h: number | undefined;
+  m: number | undefined;
+  s: number | undefined;
+};

--- a/app/consts.ts
+++ b/app/consts.ts
@@ -170,6 +170,11 @@ export const unstakingPeriodByNetwork: Record<Network, string> = {
   celestiatestnet3: "21 days",
 };
 
+export const rewardsFrequencyByNetwork: Record<Network, string> = {
+  celestia: "15s",
+  celestiatestnet3: "15s",
+};
+
 export const SITE_TITLE = "Staking.xyz";
 export const SITE_DESCRIPTION = "Your portal to staking.";
 export const SITE_URL = "https://staking.xyz";


### PR DESCRIPTION
## Changes
- Add rewards and rewards/history pages with fake endpoints
- Create `getDynamicAssetValueFromCoin` util and `useDynamicAssetValueFromCoin` hook to handle currency/coin numeric values
- Create new time util functions to handle formatted time values