### PR TITLE
feat: add tx explorer URL tag

### DIFF
--- a/app/(root)/stake/_components/StakingProcedureDialog.tsx
+++ b/app/(root)/stake/_components/StakingProcedureDialog.tsx
@@ -3,14 +3,17 @@ import type { StakeProcedure, StakeProcedureStep, StakeProcedureState } from "..
 import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useDialog } from "../../../_contexts/UIContext";
+import { useShell } from "../../../_contexts/ShellContext";
 import { useWallet } from "../../../_contexts/WalletContext";
 import { useStaking } from "../../../_contexts/StakingContext";
 import * as DelegationDialog from "../../../_components/DelegationDialog";
 import { useLinkWithSearchParams } from "../../../_utils/routes";
 import { usePostHogEvent } from "../../../_services/postHog/hooks";
+import { networkExplorer } from "../../../consts";
 
 export const StakingProcedureDialog = () => {
   const router = useRouter();
+  const { network } = useShell();
   const { activeWallet } = useWallet();
   const { procedures, amountInputPad, resetProceduresStates } = useStaking();
   const { open, toggleOpen } = useDialog("stakingProcedure");
@@ -57,7 +60,14 @@ export const StakingProcedureDialog = () => {
                 : undefined
             }
             tooltip={procedure.tooltip}
-            // explorerUrl={procedure?.txHash && `${networkExplorer[network || "celestia"]}tx/${procedure?.txHash}`}
+            explorerLink={
+              procedure?.txHash
+                ? {
+                    label: explorerLabelMap[procedure.step],
+                    url: procedure?.txHash && `${networkExplorer[network || "celestia"]}tx/${procedure?.txHash}`,
+                  }
+                : undefined
+            }
           >
             {procedure.stepName}
           </DelegationDialog.StepItem>
@@ -162,4 +172,9 @@ const ctaTextMap: Record<StakeProcedureStep, Record<StakeProcedureState, string>
     success: "Confirmed",
     error: "Try again",
   },
+};
+
+const explorerLabelMap: Record<StakeProcedureStep, string> = {
+  auth: "Approved",
+  delegate: "Signed",
 };

--- a/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
+++ b/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
@@ -3,14 +3,17 @@ import type { UnstakeProcedure, UnstakeProcedureStep, UnstakeProcedureState } fr
 import { useMemo, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useDialog } from "../../../_contexts/UIContext";
+import { useShell } from "../../../_contexts/ShellContext";
 import { useWallet } from "../../../_contexts/WalletContext";
 import { useUnstaking } from "../../../_contexts/UnstakingContext";
 import * as DelegationDialog from "../../../_components/DelegationDialog";
 import { useLinkWithSearchParams } from "../../../_utils/routes";
 import { usePostHogEvent } from "../../../_services/postHog/hooks";
+import { networkExplorer } from "../../../consts";
 
 export const UnstakingProcedureDialog = () => {
   const router = useRouter();
+  const { network } = useShell();
   const { activeWallet } = useWallet();
   const { procedures, amountInputPad, resetProceduresStates } = useUnstaking();
   const { open, toggleOpen } = useDialog("unstakingProcedure");
@@ -57,7 +60,14 @@ export const UnstakingProcedureDialog = () => {
                 : undefined
             }
             tooltip={procedure.tooltip}
-            // explorerUrl={procedure?.txHash && `${networkExplorer[network || "celestia"]}tx/${procedure?.txHash}`}
+            explorerLink={
+              procedure?.txHash
+                ? {
+                    label: explorerLabelMap[procedure.step],
+                    url: procedure?.txHash && `${networkExplorer[network || "celestia"]}tx/${procedure?.txHash}`,
+                  }
+                : undefined
+            }
           >
             {procedure.stepName}
           </DelegationDialog.StepItem>
@@ -151,4 +161,9 @@ const ctaTextMap: Record<UnstakeProcedureStep, Record<UnstakeProcedureState, str
     success: "Confirmed",
     error: "Try again",
   },
+};
+
+const explorerLabelMap: Record<UnstakeProcedureStep, string> = {
+  auth: "Approved",
+  undelegate: "Signed",
 };

--- a/app/_components/DelegationDialog/delegationDialog.css.ts
+++ b/app/_components/DelegationDialog/delegationDialog.css.ts
@@ -102,3 +102,15 @@ export const cancelButton = style({
     },
   },
 });
+
+export const successTag = style({
+  paddingInlineEnd: pxToRem(4),
+});
+export const successTagIcon = style({
+  selectors: {
+    [`${successTag}:hover &`]: {
+      transition: "transform 0.2s",
+      transform: "translate3d(1px, -1px, 0)",
+    },
+  },
+});

--- a/app/_components/DelegationDialog/index.tsx
+++ b/app/_components/DelegationDialog/index.tsx
@@ -41,7 +41,7 @@ export const StepsBox = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export const StepItem = ({ state, explorerUrl, tooltip, children, onCancel }: StepItemProps) => {
+export const StepItem = ({ state, explorerLink, tooltip, children, onCancel }: StepItemProps) => {
   return (
     <InfoCard.StackItem>
       <InfoCard.TitleBox>
@@ -54,9 +54,11 @@ export const StepItem = ({ state, explorerUrl, tooltip, children, onCancel }: St
       <div className={cn(S.itemEndBox)}>
         {state === "loading" && <LoadingSpinner size={14} />}
         {state === "error" && <MessageTag variant="warning">Failed</MessageTag>}
-        {explorerUrl && state === "success" && (
-          <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
-            <Icon name="external-link" size={14} />
+        {explorerLink && state === "success" && (
+          <a href={explorerLink.url} target="_blank" rel="noopener noreferrer">
+            <MessageTag className={S.successTag} variant="success">
+              {explorerLink.label} <Icon className={S.successTagIcon} name="external-link" size={10} />
+            </MessageTag>
           </a>
         )}
         {onCancel && state === "loading" && (
@@ -119,7 +121,10 @@ export type TopBoxProps = {
 };
 export type StepItemProps = {
   state: "idle" | "active" | "loading" | "success" | "error";
-  explorerUrl?: string;
+  explorerLink?: {
+    url: string;
+    label: string;
+  };
   tooltip?: ReactNode;
   children: ReactNode;
   onCancel?: () => void;

--- a/app/_components/MessageTag/index.tsx
+++ b/app/_components/MessageTag/index.tsx
@@ -4,9 +4,10 @@ import cn from "classnames";
 import { tag } from "./messageTag.css";
 
 export type MessageTagProps = TagVariants & {
+  className?: string;
   children: ReactNode;
 };
 
-export const MessageTag = ({ variant, children }: MessageTagProps) => {
-  return <p className={cn(tag({ variant }))}>{children}</p>;
+export const MessageTag = ({ variant, className, children }: MessageTagProps) => {
+  return <p className={cn(tag({ variant }), className)}>{children}</p>;
 };

--- a/app/_services/cosmos/hooks.tsx
+++ b/app/_services/cosmos/hooks.tsx
@@ -113,7 +113,7 @@ export const useCosmosUnstakingProcedures = ({
 
   return {
     baseProcedures: procedures,
-    firstStep: isAddressAuthorized ? procedures[1].step : procedures[0].step,
+    isAuthApproved: isAddressAuthorized,
     refetchAuthCheck: refetch,
   };
 };
@@ -275,7 +275,7 @@ export const useCosmosStakingProcedures = ({
 
   return {
     baseProcedures,
-    firstStep: isAddressAuthorized ? baseProcedures[1].step : baseProcedures[0].step,
+    isAuthApproved: isAddressAuthorized,
     refetchAuthCheck: refetch,
   };
 };

--- a/app/_services/stake/hooks.tsx
+++ b/app/_services/stake/hooks.tsx
@@ -21,7 +21,7 @@ export const useStakingProcedures = ({
 
   const {
     baseProcedures: cosmosBaseProcedures,
-    firstStep,
+    isAuthApproved,
     refetchAuthCheck,
   } = useCosmosStakingProcedures({
     amount,
@@ -77,15 +77,15 @@ export const useStakingProcedures = ({
 
   useEffect(() => {
     if (cosmosBaseProcedures?.length && authState.state === null && delegateState.state === null) {
-      if (firstStep === "auth") {
+      if (!isAuthApproved) {
         authState.setState("active");
         delegateState.setState("idle");
-      } else if (firstStep === "delegate") {
+      } else {
         authState.setState("success");
         delegateState.setState("active");
       }
     }
-  }, [cosmosBaseProcedures?.length]);
+  }, [cosmosBaseProcedures?.length, isAuthApproved]);
 
   useEffect(() => {
     if (cosmosBaseProcedures?.length) {
@@ -127,10 +127,10 @@ export const useStakingProcedures = ({
     procedures,
     resetStates: async () => {
       if (cosmosBaseProcedures?.length) {
-        authState.setState(firstStep === "auth" ? "active" : null);
+        authState.setState(isAuthApproved ? "success" : "active");
         authState.setTxHash(undefined);
         authState.setError(null);
-        delegateState.setState(firstStep === "delegate" ? "active" : "idle");
+        delegateState.setState(!isAuthApproved ? "idle" : "active");
         delegateState.setTxHash(undefined);
         delegateState.setError(null);
         await refetchAuthCheck?.();

--- a/app/_services/unstake/hooks.tsx
+++ b/app/_services/unstake/hooks.tsx
@@ -21,7 +21,7 @@ export const useUnstakingProcedures = ({
 
   const {
     baseProcedures: cosmosBaseProcedures,
-    firstStep,
+    isAuthApproved,
     refetchAuthCheck,
   } = useCosmosUnstakingProcedures({
     amount,
@@ -77,10 +77,10 @@ export const useUnstakingProcedures = ({
 
   useEffect(() => {
     if (cosmosBaseProcedures?.length && authState.state === null && undelegateState.state === null) {
-      if (firstStep === "auth") {
+      if (!isAuthApproved) {
         authState.setState("active");
         undelegateState.setState("idle");
-      } else if (firstStep === "undelegate") {
+      } else {
         authState.setState("success");
         undelegateState.setState("active");
       }
@@ -127,10 +127,10 @@ export const useUnstakingProcedures = ({
     procedures,
     resetStates: async () => {
       if (cosmosBaseProcedures?.length) {
-        authState.setState(firstStep === "auth" ? "active" : null);
+        authState.setState(isAuthApproved ? "success" : "active");
         authState.setTxHash(undefined);
         authState.setError(null);
-        undelegateState.setState(firstStep === "undelegate" ? "active" : "idle");
+        undelegateState.setState(!isAuthApproved ? "idle" : "active");
         undelegateState.setTxHash(undefined);
         undelegateState.setError(null);
         await refetchAuthCheck?.();


### PR DESCRIPTION
## Changes
- Add the explorer link tag to the tx flow steps
- Replace the `firstStep` value with the `isAuthApproved` to fix the logic that results in the incorrect auth step state bug (see the recording)

https://github.com/Apybara/staking-xyz-widget/assets/14227221/78998a01-0b48-4478-a20c-1a43628f2b67

## Notes
- Because the approval `txHash` is currently blocked by the BE, we can't show the tag for the auth step on the FE yet. We can merge this PR but keep the ticket open with a blocked status.