### PR TITLE
fix: tx number decimal point

### DIFF
--- a/app/_services/cosmos/utils.ts
+++ b/app/_services/cosmos/utils.ts
@@ -20,7 +20,7 @@ export const getCoinValueFromDenom = ({ network, amount }: { network: CosmosNetw
 
 export const getDenomValueFromCoin = ({ network, amount }: { network: CosmosNetwork; amount?: string | number }) => {
   const exponent = getExponent(network);
-  return new BigNumber(amount || 0).multipliedBy(10 ** exponent).toString();
+  return Math.floor(new BigNumber(amount || 0).multipliedBy(10 ** exponent).toNumber()).toString();
 };
 
 export const getChainAssets = (network: CosmosNetwork) => {

--- a/app/_services/stake/index.ts
+++ b/app/_services/stake/index.ts
@@ -3,5 +3,5 @@ import BigNumber from "bignumber.js";
 import { feeRatioByNetwork } from "../../consts";
 
 export const getFeeCollectingAmount = ({ amount, network }: { amount: string; network: Network }) => {
-  return BigNumber(amount).times(feeRatioByNetwork[network]).toString();
+  return Math.floor(BigNumber(amount).times(feeRatioByNetwork[network]).toNumber()).toString();
 };


### PR DESCRIPTION
## Changes
- Fix the staking, fee, and unstaking amount bug if value is lower than the denom's decimal count (i.e., 6 in Cosmos networks)

## Description
At the moment, if you put in $1 USD, the TIA amount would be `0.0948453`. The correct `utia` amount in this case should be `94845`, instead of `94845.3`. This value with the decimal point results in an error.

![Screenshot 2024-04-26 at 1 48 21 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/46a11c5d-623c-4981-a98c-0e6eaca7d900)
![Screenshot 2024-04-26 at 1 48 26 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/0d565752-02a1-4184-894a-a11c78cc094a)
![Screenshot 2024-04-26 at 1 48 13 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/b3cb3102-946b-409b-8171-372fe9d02193)