### PR TITLE
chore: close tx dialog when disconnected

### DIFF
--- a/app/(root)/stake/_components/StakingProcedureDialog.tsx
+++ b/app/(root)/stake/_components/StakingProcedureDialog.tsx
@@ -14,7 +14,7 @@ import { networkExplorer } from "../../../consts";
 export const StakingProcedureDialog = () => {
   const router = useRouter();
   const { network } = useShell();
-  const { activeWallet } = useWallet();
+  const { connectionStatus, activeWallet } = useWallet();
   const { procedures, amountInputPad, resetProceduresStates } = useStaking();
   const { open, toggleOpen } = useDialog("stakingProcedure");
   const activityLink = useLinkWithSearchParams("activity");
@@ -29,6 +29,12 @@ export const StakingProcedureDialog = () => {
     if (!uncheckedProcedures?.[0]) return ctaTextMap.auth.idle;
     return ctaTextMap[uncheckedProcedures[0].step][uncheckedProcedures[0].state || "idle"];
   }, [uncheckedProcedures?.[0]?.step, uncheckedProcedures?.[0]?.state]);
+
+  useEffect(() => {
+    if (connectionStatus === "disconnected" && open) {
+      toggleOpen(false);
+    }
+  }, [connectionStatus, open]);
 
   usePostHogEvents({ open, amount: amountInputPad.primaryValue, uncheckedProcedures, procedures });
 

--- a/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
+++ b/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
@@ -14,7 +14,7 @@ import { networkExplorer } from "../../../consts";
 export const UnstakingProcedureDialog = () => {
   const router = useRouter();
   const { network } = useShell();
-  const { activeWallet } = useWallet();
+  const { connectionStatus, activeWallet } = useWallet();
   const { procedures, amountInputPad, resetProceduresStates } = useUnstaking();
   const { open, toggleOpen } = useDialog("unstakingProcedure");
   const activityLink = useLinkWithSearchParams("activity");
@@ -29,6 +29,12 @@ export const UnstakingProcedureDialog = () => {
     if (!uncheckedProcedures?.[0]) return ctaTextMap.undelegate.idle;
     return ctaTextMap[uncheckedProcedures[0].step][uncheckedProcedures[0].state || "idle"];
   }, [uncheckedProcedures?.[0]?.step, uncheckedProcedures?.[0]?.state]);
+
+  useEffect(() => {
+    if (connectionStatus === "disconnected" && open) {
+      toggleOpen(false);
+    }
+  }, [connectionStatus, open]);
 
   usePostHogEvents({ open, amount: amountInputPad.primaryValue, uncheckedProcedures, procedures });
 


### PR DESCRIPTION
## To review
Connect to wallet and trigger the tx flow (either on stake or unstake page) dialog on the first step. Do nothing and wait for the wallet to be disconnected (it probably takes about 20 minutes). When disconnected, the dialog should be closed.