### PR TITLE
chore: redirect Aleo network

### DIFF
--- a/app/_actions/redirectPage.ts
+++ b/app/_actions/redirectPage.ts
@@ -9,6 +9,10 @@ export default async function redirectPage(searchParams: RouterStruct["searchPar
   const { network, currency } = searchParams || {};
   const current = getCurrentSearchParams(searchParams);
 
+  if (network?.toLowerCase() === "aleo") {
+    redirect("https://aleo.staking.xyz");
+  }
+
   const isNetworkInvalid = !network || !networkRegex.test(network);
   const isCurrencyInvalid = !currencyRegex.test(currency || "");
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,23 @@ import { createVanillaExtractPlugin } from "@vanilla-extract/next-plugin";
 const withVanillaExtract = createVanillaExtractPlugin();
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  redirects: async () => {
+    return [
+      {
+        source: "/path/:path*",
+        has: [
+          {
+            type: "query",
+            key: "network",
+            value: "aleo",
+          },
+        ],
+        destination: "https://aleo.staking.xyz",
+        permanent: false,
+      },
+    ];
+  },
+};
 
 export default withVanillaExtract(nextConfig);


### PR DESCRIPTION
## Changes
- Redirect to "aleo.staking.xyz" whenever the network search param is "aleo"

## Note
- @eddy-apybara I know you prefer to mask "aleo.staking.xyz" URL as "staking.xyz?network=aleo", but there's no easy solution to implement this URL masking request. But I believe this is not a problem in the short term.