### PR TITLE
fix: CosmosKit wallet disconnect issue

### DIFF
--- a/app/_components/WalletAccountDialog/index.tsx
+++ b/app/_components/WalletAccountDialog/index.tsx
@@ -2,6 +2,7 @@
 import { useDialog } from "../../_contexts/UIContext";
 import { useShell } from "../../_contexts/ShellContext";
 import { useWallet } from "../../_contexts/WalletContext";
+import { useActiveWalletStates } from "../../_contexts/WalletContext/hooks";
 import { useProceduralStates } from "../../_utils/hooks";
 import { usePostHogEvent } from "../../_services/postHog/hooks";
 import { useWalletBalance, useWalletDisconnectors } from "../../_services/wallet/hooks";
@@ -11,7 +12,7 @@ import { RootWalletAccountDialog } from "./RootWalletAccountDialog";
 
 export const WalletAccountDialog = () => {
   const { network } = useShell();
-  const { activeWallet, address } = useWallet();
+  const { activeWallet, address, setStates } = useWallet();
   const {
     data: balanceData,
     isLoading: isBalanceLoading,
@@ -21,6 +22,10 @@ export const WalletAccountDialog = () => {
   const { isLoading, setIsLoading, error, setError } = useProceduralStates();
   const { open, toggleOpen } = useDialog("walletAccount");
   const disconnectors = useWalletDisconnectors(network || defaultNetwork);
+
+  // NOTE: triggering this hook here to ensure CosmosKit wallet status are updated.
+  // The `useCosmosWalletStates` hook triggered in WalletContext doesn't update the status for unknown reasons.
+  useActiveWalletStates({ setStates });
 
   const captureDisconnectSuccess = usePostHogEvent("wallet_disconnect_succeeded");
 

--- a/app/_contexts/WalletContext/hooks.tsx
+++ b/app/_contexts/WalletContext/hooks.tsx
@@ -26,25 +26,14 @@ export const useWalletsSupport = ({ setStates }: { setStates: WalletStates["setS
   return null;
 };
 
-export const useActiveWalletStates = ({
-  connectedAddress,
-  setStates,
-}: {
-  connectedAddress: WalletStates["connectedAddress"];
-  setStates: WalletStates["setStates"];
-}) => {
+export const useActiveWalletStates = ({ setStates }: { setStates: WalletStates["setStates"] }) => {
   const { network } = useShell();
   const isCosmosNetwork = network && getIsCosmosNetwork(network);
   const cosmosWalletStates = useCosmosWalletStates({ network: isCosmosNetwork ? network : undefined });
 
   useEffect(() => {
     if (isCosmosNetwork) {
-      setStates({
-        ...cosmosWalletStates,
-        connectedAddress: cosmosWalletStates.address
-          ? [...connectedAddress, cosmosWalletStates.address]
-          : connectedAddress,
-      });
+      setStates(cosmosWalletStates);
       return;
     }
   }, [

--- a/app/_contexts/WalletContext/index.tsx
+++ b/app/_contexts/WalletContext/index.tsx
@@ -12,13 +12,8 @@ export const WalletProvider = ({ children }: T.WalletProviderProps) => {
   const [states, setStates] = useReducer<T.UseWalletReducer>((prev, next) => ({ ...prev, ...next }), initialStates);
 
   useWalletsSupport({ setStates });
-  const { connectionStatus, activeWallet } =
-    useActiveWalletStates({ connectedAddress: states.connectedAddress, setStates }) || {};
-  useIsWalletConnectingEagerly({
-    connectionStatus: connectionStatus || "disconnected",
-    activeWallet: activeWallet || null,
-    setStates,
-  });
+  useActiveWalletStates({ setStates });
+  useIsWalletConnectingEagerly(states);
 
   // Failed connection event is tracked in WalletConnectionDialog
   const captureWalletConnectSuccess = usePostHogEvent("wallet_connect_succeeded");
@@ -52,7 +47,6 @@ const initialStates: T.WalletContext = {
   activeWallet: null,
   address: null,
   connectionStatus: "disconnected",
-  isEagerlyConnecting: undefined,
-  connectedAddress: [],
-  setStates: () => {},
+  isEagerlyConnecting: false,
+  setStates: () => { },
 };

--- a/app/_contexts/WalletContext/types.ts
+++ b/app/_contexts/WalletContext/types.ts
@@ -9,7 +9,6 @@ export type WalletStates = {
   address: string | null;
   connectionStatus: WalletConnectionStatus;
   isEagerlyConnecting?: boolean;
-  connectedAddress: Array<string>;
   setStates: Dispatch<Partial<WalletStates>>;
 };
 

--- a/app/_contexts/WidgetContext/hooks.tsx
+++ b/app/_contexts/WidgetContext/hooks.tsx
@@ -7,13 +7,13 @@ import { useWallet } from "../WalletContext";
 export const useWidgetRouterGate = ({ status, setStates }: WidgetStates) => {
   const router = useRouter();
   const pathname = usePathname();
-  const { connectionStatus, connectedAddress } = useWallet();
+  const { connectionStatus } = useWallet();
   const stakePageLink = useLinkWithSearchParams("stake");
   const homePageLink = useLinkWithSearchParams("");
 
   useEffect(() => {
     // Redirect to the stake page on initial visit
-    if (connectionStatus === "disconnected" && !connectedAddress.length && pathname === "/" && status === "loading") {
+    if (connectionStatus === "disconnected" && pathname === "/" && status === "loading") {
       router.push(stakePageLink);
       return;
     }
@@ -29,5 +29,5 @@ export const useWidgetRouterGate = ({ status, setStates }: WidgetStates) => {
     }
 
     setStates({ status: "loaded" });
-  }, [pathname, connectedAddress, connectionStatus]);
+  }, [pathname, connectionStatus]);
 };


### PR DESCRIPTION
## Changes
- Trigger `useActiveWalletStates` in `WalletAccountDialog` to get the synced status from CosmosKit
- Remove the unused `connectedAddress` value from `WidgetContext`

## To review
- Just try to connect, reject connection, connect again, disconnect to different wallets and repeat the actions

## Notes
- For unknown reason, CosmosKit's `useChain` hook in `useCosmosWalletStates` hook gets unsynced with the latest status after a few connection/rejection actions. The inconsistent behavior from the `useChain` hook doesn't make sense, but most likely a bug from CosmosKit package.