### PR TITLE
fix: revalidate GitHub release tag on visit

### DIFF
--- a/app/(root)/more/page.tsx
+++ b/app/(root)/more/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { RouterStruct } from "../../types";
+import { revalidateTag } from "next/cache";
 import { getLinkWithSearchParams } from "../../_utils/routes";
 import { getLatestReleaseTag } from "../../_services/gitHub";
 import { PageViewTop } from "../_components/WidgetTop";
@@ -11,6 +12,7 @@ import * as S from "./_components/more.css";
 
 export default async function More({ searchParams }: RouterStruct) {
   const latestReleaseTag = await getLatestReleaseTag();
+  revalidateTag("latestReleaseFromGitHub");
 
   return (
     <>

--- a/app/_services/gitHub/index.ts
+++ b/app/_services/gitHub/index.ts
@@ -19,7 +19,7 @@ const getLatestRelease = async (): Promise<LatestReleaseResponse> => {
       "X-GitHub-Api-Version": "2022-11-28",
     } as HeadersInit,
     next: {
-      revalidate: 43200, // 12 hours
+      revalidate: 3600,
       tags: ["latestReleaseFromGitHub"],
     },
   });


### PR DESCRIPTION
## Changes
- Revalidate the query whenever user visits the page
- Decrease cache time 

## Notes
- This is very odd because the staging site is getting the correct v0.0.3 version, but production branch is not. I'm still confused by the root cause. Let's give this change a try one more shot. If it still doesn't work, we'll just give up on fetching the release tag on the fly and use static environment variable.