### PR TITLE
chore: added loading and empty state to unstake info box

### DIFF
--- a/app/(root)/unstake/_components/unstake.css.ts
+++ b/app/(root)/unstake/_components/unstake.css.ts
@@ -1,13 +1,37 @@
 import { globalStyle, style } from "@vanilla-extract/css";
 import { colors, weights } from "../../../../theme/theme.css";
 import { pxToRem } from "../../../../theme/utils";
+import { recipe } from "@vanilla-extract/recipes";
 
-export const triggerTexts = style({
-  flexGrow: 1,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "space-between",
+export const triggerButton = style({
+  selectors: {
+    "&:disabled": {
+      pointerEvents: "none",
+    },
+  },
 });
+
+export const triggerTexts = recipe({
+  base: {
+    flexGrow: 1,
+    display: "flex",
+    alignItems: "center",
+  },
+  variants: {
+    state: {
+      default: {
+        justifyContent: "space-between",
+      },
+      disabled: {
+        justifyContent: "center",
+      },
+    },
+  },
+  defaultVariants: {
+    state: "default",
+  },
+});
+
 export const triggerProgressText = style({
   fontSize: pxToRem(14),
   color: colors.black300,

--- a/app/_components/AccordionInfoCard/index.tsx
+++ b/app/_components/AccordionInfoCard/index.tsx
@@ -35,7 +35,7 @@ export const Trigger = forwardRef(
     <Accordion.Header className={cn(S.itemHeader, "accordionInfoCardHeader")}>
       <Accordion.Trigger className={cn(S.trigger, className)} {...props} ref={forwardedRef}>
         {children}
-        <Icon name="chevron" size={14} className={cn(S.triggerIcon)} aria-hidden />
+        {!props.disabled && <Icon name="chevron" size={14} className={cn(S.triggerIcon)} aria-hidden />}
       </Accordion.Trigger>
     </Accordion.Header>
   ),


### PR DESCRIPTION
## Changes
- Added a skeleton loader to the Unstake "In-progress" box
- @eddy-apybara @vince19972 I've also added an empty state for when there's no unstaking in progress. Screenshot below; let me know if you'd like to change it to something else
- Hid the Accordion chevron icon when the accordion is disabled

<img width="400" alt="Screenshot 2024-05-13 at 16 00 22" src="https://github.com/Apybara/staking-xyz-widget/assets/17300315/a1d809ab-ab28-490c-a55e-f3bc3d65e4ea">
