### PR TITLE
fix: reset pagination on filter change

### DIFF
--- a/app/_services/stakingOperator/hooks.tsx
+++ b/app/_services/stakingOperator/hooks.tsx
@@ -1,6 +1,6 @@
 import type { Network } from "../../types";
 import * as T from "./types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useShell } from "../../_contexts/ShellContext";
 import { useWallet } from "../../_contexts/WalletContext";
 import {
@@ -55,6 +55,12 @@ export const useAddressActivityQueryParams = (defaultParams: T.AddressActivityPa
   const [filterKey, setFilterKey] = useState<T.AddressActivityPaginationParams["filterKey"]>(
     defaultParams?.filterKey || "transactions",
   );
+
+  useEffect(() => {
+    if (offset !== 0) {
+      setOffset(0);
+    }
+  }, [filterKey, limit]);
 
   return {
     offset,


### PR DESCRIPTION
## To review
- Make sure your activities are more than 6 to have the second page
- On production site, paginate to the 2nd offset on activity page, and change filter to "Stake", you should see that the pagination is either still "2" (if you have more than 6 stake activities), or an empty view (if you have less than 6 stake activities).
- On this preview link, this problem should be fixed. The pagination offset should be reset every time the filter is changed.