### PR TITLE
feat: integrate inProgress activity value

### DIFF
--- a/app/(root)/activity/_components/ActivityTable.tsx
+++ b/app/(root)/activity/_components/ActivityTable.tsx
@@ -7,7 +7,7 @@ import * as ListTable from "../../../_components/ListTable";
 import { EmptyState } from "../../../_components/EmptyState";
 import { ErrorRetryModule } from "../../../_components/ErrorRetryModule";
 import { getPercentagedNumber } from "../../../_utils/number";
-import { getUTCStringFromUnixTimestamp } from "../../../_utils/time";
+import { getUTCStringFromUnixTimestamp, getUTCStringFromUnixTimeString } from "../../../_utils/time";
 import { useDynamicAssetValueFromCoin } from "../../../_utils/conversions/hooks";
 import { useActivity } from "../../../_services/stakingOperator/hooks";
 import { networkExplorer, defaultNetwork } from "../../../consts";
@@ -107,7 +107,11 @@ const ListItem = ({
           isProcessing={activity.inProgress}
         />
         <ListTable.TxInfoSecondary
-          time={getUTCStringFromUnixTimestamp(activity.timestamp)}
+          time={
+            !activity.inProgress
+              ? getUTCStringFromUnixTimestamp(activity.timestamp)
+              : getUTCStringFromUnixTimeString(activity.created_at)
+          }
           reward={`Reward ${getPercentagedNumber(activity.rewardRate)}`}
           isProcessing={activity.inProgress}
         />

--- a/app/(root)/rewards/_components/HistoryTable/index.tsx
+++ b/app/(root)/rewards/_components/HistoryTable/index.tsx
@@ -7,7 +7,7 @@ import * as ListTable from "../../../../_components/ListTable";
 import { EmptyState } from "../../../../_components/EmptyState";
 import { ErrorRetryModule } from "../../../../_components/ErrorRetryModule";
 import { getPercentagedNumber } from "../../../../_utils/number";
-import { getUTCStringFromUnixTimestamp } from "../../../../_utils/time";
+import { getUTCStringFromUnixTimestamp, getUTCStringFromUnixTimeString } from "../../../../_utils/time";
 import { useDynamicAssetValueFromCoin } from "../../../../_utils/conversions/hooks";
 import { useRewardsHistory } from "../../../../_services/stakingOperator/hooks";
 import { networkExplorer, defaultNetwork } from "../../../../consts";
@@ -91,7 +91,11 @@ const ListItem = ({
           isProcessing={rewardsHistory.inProgress}
         />
         <ListTable.TxInfoSecondary
-          time={getUTCStringFromUnixTimestamp(rewardsHistory.timestamp)}
+          time={
+            !rewardsHistory.inProgress
+              ? getUTCStringFromUnixTimestamp(rewardsHistory.timestamp)
+              : getUTCStringFromUnixTimeString(rewardsHistory.created_at)
+          }
           reward={`Reward ${getPercentagedNumber(rewardsHistory.rewardRate)}`}
           isProcessing={rewardsHistory.inProgress}
         />

--- a/app/_services/stakingOperator/types.ts
+++ b/app/_services/stakingOperator/types.ts
@@ -187,6 +187,7 @@ export type ActivityItem = {
   amount: number;
   rewardRate: number;
   timestamp: number;
+  created_at: string;
   completionTime?: number;
   txHash: string;
   inProgress?: boolean;
@@ -216,6 +217,7 @@ export type RewardsHistoryItem = {
   amount: number;
   rewardRate: number;
   timestamp: number;
+  created_at: string;
   txHash: string;
   inProgress?: boolean;
 };

--- a/app/_utils/time.ts
+++ b/app/_utils/time.ts
@@ -100,6 +100,10 @@ export const getUTCStringFromUnixTimestamp = (timestamp: number) => {
   return getFormattedUTCString(fromUnixTime(timestamp));
 };
 
+export const getUTCStringFromUnixTimeString = (time: string) => {
+  return getFormattedUTCString(moment(time).toDate());
+};
+
 const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 type TimeUnits = {


### PR DESCRIPTION
## Changes
- Integrate the `created_at` time from the `inProgress` activity entries

## To review
- Stake or unstake, and go to activity page.
- You should either see the latest tx shows up with "All" filter or "Stake"/"Unstake" filter with a correct time, and possibly a loading icon.
- You should not see a invalid time, or missing the new tx.
