### PR TITLE
fix: filter out in-progress unstakes

### DIFF
--- a/app/(root)/_components/UnstakeNavCard.tsx
+++ b/app/(root)/_components/UnstakeNavCard.tsx
@@ -16,12 +16,13 @@ export const UnstakeNavCard = (props: NavCard.PageNavCardProps) => {
       limit: 1,
     }) || {};
   const { formattedEntries, totalEntries, isLoading, error } = unstakeActivityQuery || {};
+  const inProgressEntries = formattedEntries?.filter((item) => !!item.completionTime);
 
   const isDisabled =
     connectionStatus !== "connected" ||
     !!error ||
     isLoading ||
-    (stakedBalance === "0" && (!formattedEntries?.length || totalEntries === 0));
+    (stakedBalance === "0" && (!inProgressEntries?.length || totalEntries === 0));
 
   const endBoxValue = useMemo(() => {
     if (connectionStatus !== "connected") return undefined;
@@ -40,8 +41,8 @@ export const UnstakeNavCard = (props: NavCard.PageNavCardProps) => {
         ),
       };
     }
-    if (formattedEntries?.length && totalEntries) {
-      const times = formattedEntries[0].completionTime && getTimeUnitStrings(formattedEntries[0].completionTime);
+    if (inProgressEntries?.length && totalEntries) {
+      const times = inProgressEntries[0].completionTime && getTimeUnitStrings(inProgressEntries[0].completionTime);
 
       return {
         title: <NavCard.SecondaryText>In progress {totalEntries}</NavCard.SecondaryText>,
@@ -52,7 +53,7 @@ export const UnstakeNavCard = (props: NavCard.PageNavCardProps) => {
         ),
       };
     }
-  }, [connectionStatus, totalEntries, formattedEntries, isLoading]);
+  }, [connectionStatus, totalEntries, inProgressEntries, isLoading]);
 
   return <NavCard.Card {...props} page="unstake" disabled={isDisabled} endBox={endBoxValue} />;
 };

--- a/app/(root)/unstake/_components/UnstakeInfoBox.tsx
+++ b/app/(root)/unstake/_components/UnstakeInfoBox.tsx
@@ -28,21 +28,22 @@ export const UnstakeInfoBox = () => {
       limit: totalEntries || 999,
     }) || {};
   const { formattedEntries } = unstakeActivityQuery || {};
+  const inProgressEntries = formattedEntries?.filter((item) => !!item.completionTime);
 
   const totalUnbondingAmount = useMemo(() => {
-    if (!totalEntries) return undefined;
+    if (!inProgressEntries?.length) return undefined;
 
     const sumDenom =
-      formattedEntries
+      inProgressEntries
         ?.reduce((acc, { amount }) => {
           return acc.plus(amount);
         }, BigNumber(0))
         .toString() || "0";
 
     return getDynamicAssetValueFromCoin({ currency, coinPrice, network, coinVal: sumDenom });
-  }, [totalEntries, formattedEntries, currency]);
+  }, [inProgressEntries, currency]);
 
-  if (!totalEntries) return null;
+  if (!inProgressEntries?.length) return null;
 
   return (
     <AccordionInfoCard.Root>
@@ -50,14 +51,14 @@ export const UnstakeInfoBox = () => {
         <AccordionInfoCard.Trigger>
           <div className={cn(S.triggerTexts)}>
             <p className={cn(S.triggerProgressText)}>
-              In progress <span className={cn(S.triggerCountText)}>{totalEntries}</span>
+              In progress <span className={cn(S.triggerCountText)}>{inProgressEntries?.length}</span>
             </p>
             <span className={cn(S.triggerAmountText)}>{totalUnbondingAmount}</span>
           </div>
         </AccordionInfoCard.Trigger>
         <AccordionInfoCard.Content>
           <AccordionInfoCard.Stack>
-            {formattedEntries?.map((item, index) => {
+            {inProgressEntries?.map((item, index) => {
               const times = item.completionTime && getTimeUnitStrings(item.completionTime);
 
               return (

--- a/app/_services/stakingOperator/celestia/hooks.tsx
+++ b/app/_services/stakingOperator/celestia/hooks.tsx
@@ -138,7 +138,9 @@ export const useCelestiaAddressActivity = ({
     formattedEntries: data?.data?.entries?.map((entry) => ({
       ...entry,
       amount: getCoinValueFromDenom({ network: network || "celestia", amount: entry.amount }),
-      completionTime: getTimeDiffInSingleUnits(fromUnixTime(entry.completionTime || 0)),
+      completionTime: entry.completionTime
+        ? getTimeDiffInSingleUnits(fromUnixTime(entry.completionTime || 0))
+        : undefined,
     })),
     totalEntries,
     lastOffset,


### PR DESCRIPTION
## Changes
- Filter out unstake entries without `completionTime` value, which means the unstake entry is not going through the unstaking progress (i.e., it's already completed, or still processing the tx)

## Notes
- The difference between this PR and the staging is invisible at the moment, because none of us have completed unstakes recorded in the staking operator database. 