### PR TITLE
chore: refresh app when staking/unstaking tx is done

### DIFF
--- a/app/(root)/stake/_components/StakingProcedureDialog.tsx
+++ b/app/(root)/stake/_components/StakingProcedureDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { StakeProcedure, StakeProcedureStep, StakeProcedureState } from "../../../_services/stake/types";
 import { useEffect, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useDialog } from "../../../_contexts/UIContext";
 import { useShell } from "../../../_contexts/ShellContext";
@@ -13,6 +14,7 @@ import { networkExplorer, defaultNetwork } from "../../../consts";
 
 export const StakingProcedureDialog = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { network } = useShell();
   const { connectionStatus, activeWallet } = useWallet();
   const { procedures, amountInputPad, inputState, resetProceduresStates } = useStaking();
@@ -96,6 +98,7 @@ export const StakingProcedureDialog = () => {
           onDismissButtonClick={() => {
             amountInputPad.setPrimaryValue("");
             resetProceduresStates();
+            queryClient.resetQueries();
             toggleOpen(false);
           }}
         />

--- a/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
+++ b/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { UnstakeProcedure, UnstakeProcedureStep, UnstakeProcedureState } from "../../../_services/unstake/types";
 import { useMemo, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useDialog } from "../../../_contexts/UIContext";
 import { useShell } from "../../../_contexts/ShellContext";
@@ -13,6 +14,7 @@ import { networkExplorer, defaultNetwork } from "../../../consts";
 
 export const UnstakingProcedureDialog = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { network } = useShell();
   const { connectionStatus, activeWallet } = useWallet();
   const { procedures, amountInputPad, inputState, resetProceduresStates } = useUnstaking();
@@ -96,6 +98,7 @@ export const UnstakingProcedureDialog = () => {
           onDismissButtonClick={() => {
             amountInputPad.setPrimaryValue("");
             resetProceduresStates();
+            queryClient.resetQueries();
             toggleOpen(false);
           }}
         />


### PR DESCRIPTION
## Changes
Queries are reset (refetched) when the Staking / Unstaking dialogs are closed after successful tx