### PR TITLE
fix: testnet undefined signer

### DIFF
--- a/app/_services/cosmos/consts.ts
+++ b/app/_services/cosmos/consts.ts
@@ -1,5 +1,5 @@
 import type { ChainInfo } from "@keplr-wallet/types";
-import type { CosmosTestnet } from "../../types";
+import type { CosmosNetwork, CosmosTestnet } from "../../types";
 import { networkEndpoints } from "../../consts";
 
 const celestia = {
@@ -87,4 +87,9 @@ export const celestiatestnet3ChainInfo: ChainInfo = {
 
 export const cosmosTestnetChainInfo: Record<CosmosTestnet, ChainInfo> = {
   celestiatestnet3: celestiatestnet3ChainInfo,
+};
+
+export const cosmosChainInfoId: Record<CosmosNetwork, string> = {
+  celestia: celestiaChainInfo.chainId,
+  celestiatestnet3: celestiatestnet3ChainInfo.chainId,
 };

--- a/app/_services/cosmos/hooks.tsx
+++ b/app/_services/cosmos/hooks.tsx
@@ -781,7 +781,7 @@ export const useCosmosSigningClient = ({
     error,
   } = useQuery({
     enabled: !!network && !!wallet,
-    queryKey: ["cosmosSigningClient", network, wallet, offlineSignerGetter],
+    queryKey: ["cosmosSigningClient", network, wallet, !!offlineSignerGetter],
     queryFn: () => getSigningClient({ network, getOfflineSigner: offlineSignerGetter }),
   });
 

--- a/app/_services/cosmos/index.ts
+++ b/app/_services/cosmos/index.ts
@@ -18,6 +18,7 @@ import {
 import { networkDefaultGasPrice, networkEndpoints } from "../../consts";
 import { createAuthzAminoConverters } from "./amino";
 import { getCoinValueFromDenom, getChainAssets } from "./utils";
+import { cosmosChainInfoId } from "./consts";
 
 const { GenericAuthorization } = cosmos.authz.v1beta1;
 
@@ -33,7 +34,7 @@ export const getSigningClient = async ({
       throw new Error("Missing parameter: network.");
     }
 
-    const signer = getOfflineSigner ? await getOfflineSigner() : window?.getOfflineSigner?.(network);
+    const signer = getOfflineSigner ? await getOfflineSigner() : window?.getOfflineSigner?.(cosmosChainInfoId[network]);
     if (!signer) {
       throw new Error("Missing parameter: offlineSigner.");
     }


### PR DESCRIPTION
## Changes
- Revalidate `useCosmosSigningClient` query against the `offlineSignerGetter` boolean value (is `undefined` or not)
- Add `cosmosChainInfoId` map to get correct fallback offline signer from `window.getOfflineSigner` method when on testnet

## Descriptions
- The bug is resulted from the `undefined` offline signer method from `useCosmosSigningClient` and the invalid fallback method from `window.getOfflineSigner`. 
- This bug doesn't exist on mainnet because `celestia` is a valid chain ID when using fallback signer from `window.getOfflineSigner`, but `celestiatestnet3` is not.

## To review
1. To reproduce the bug, on [staging link](https://staking-xyz-widget-git-staging-apybara.vercel.app), when testnet is chosen, clear "Local storage" from the "Application" tab in Chrome browser.
  1.1. Reload the page 
  1.2. Connect to testnet, and try to send a stake/unstake tx
  1.3. You should see the "Failed" label immediately

![Screenshot 2024-05-23 at 11 04 17 AM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/68980076-654d-459f-ada5-0c84b7e75f70)

2. Follow same steps from above on testnet and mainnet, you should be able to send a tx successfully.