### PR TITLE
chore: add preparing transaction CTA copy to auth/delegate procedures

### DIFF
--- a/app/(root)/stake/_components/StakingProcedureDialog.tsx
+++ b/app/(root)/stake/_components/StakingProcedureDialog.tsx
@@ -165,7 +165,7 @@ const getActiveProcedure = (procedures: Array<StakeProcedure>) => {
   return procedures.find((procedure) => procedure.state !== "success");
 };
 const getIsLoadingState = (procedure: StakeProcedure) => {
-  return procedure?.state === "preparing" || procedure?.state === "loading";
+  return procedure?.state === "preparing" || procedure?.state === "loading" || procedure?.state === "broadcasting";
 };
 
 const ctaTextMap: Record<StakeProcedureStep, Record<StakeProcedureState, string>> = {
@@ -174,6 +174,7 @@ const ctaTextMap: Record<StakeProcedureStep, Record<StakeProcedureState, string>
     active: "Approve",
     preparing: "Preparing transaction",
     loading: "Proceed in the wallet",
+    broadcasting: "Broadcasting transaction",
     success: "Approved",
     error: "Try again",
   },
@@ -182,6 +183,7 @@ const ctaTextMap: Record<StakeProcedureStep, Record<StakeProcedureState, string>
     active: "Confirm",
     preparing: "Preparing transaction",
     loading: "Proceed in the wallet",
+    broadcasting: "Broadcasting transaction",
     success: "Confirmed",
     error: "Try again",
   },

--- a/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
+++ b/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
@@ -165,7 +165,7 @@ const getActiveProcedure = (procedures: Array<UnstakeProcedure>) => {
   return procedures.find((procedure) => procedure.state !== "success");
 };
 const getIsLoadingState = (procedure: UnstakeProcedure) => {
-  return procedure?.state === "preparing" || procedure?.state === "loading";
+  return procedure?.state === "preparing" || procedure?.state === "loading" || procedure?.state === "broadcasting";
 };
 
 const ctaTextMap: Record<UnstakeProcedureStep, Record<UnstakeProcedureState, string>> = {
@@ -174,6 +174,7 @@ const ctaTextMap: Record<UnstakeProcedureStep, Record<UnstakeProcedureState, str
     active: "Approve",
     preparing: "Preparing transaction",
     loading: "Proceed in the wallet",
+    broadcasting: "Broadcasting transaction",
     success: "Approved",
     error: "Try again",
   },
@@ -182,6 +183,7 @@ const ctaTextMap: Record<UnstakeProcedureStep, Record<UnstakeProcedureState, str
     active: "Confirm",
     preparing: "Preparing transaction",
     loading: "Proceed in the wallet",
+    broadcasting: "Broadcasting transaction",
     success: "Confirmed",
     error: "Try again",
   },

--- a/app/_components/DelegationDialog/index.tsx
+++ b/app/_components/DelegationDialog/index.tsx
@@ -54,7 +54,7 @@ export const StepItem = ({ state, explorerLink, tooltip, children, onCancel }: S
         {!!tooltip && tooltip}
       </InfoCard.TitleBox>
       <div className={cn(S.itemEndBox)}>
-        {state === "loading" && <LoadingSpinner size={14} />}
+        {(state === "loading" || state === "preparing" || state === "broadcasting") && <LoadingSpinner size={14} />}
 
         {state === "error" && (
           <a href={explorerLink?.url || "#"} target="_blank" rel="noopener noreferrer">
@@ -130,7 +130,7 @@ export type TopBoxProps = {
   type: "stake" | "unstake";
 };
 export type StepItemProps = {
-  state: "idle" | "active" | "preparing" | "loading" | "success" | "error";
+  state: "idle" | "active" | "preparing" | "loading" | "broadcasting" | "success" | "error";
   explorerLink?: {
     url: string;
     label: string;

--- a/app/_services/stake/hooks.tsx
+++ b/app/_services/stake/hooks.tsx
@@ -44,6 +44,11 @@ export const useStakingProcedures = ({
         authState.setTxHash(undefined);
         authState.setError(null);
       },
+      onBroadcasting: () => {
+        authState.setState("broadcasting");
+        authState.setTxHash(undefined);
+        authState.setError(null);
+      },
       onSuccess: (txHash) => {
         authState.setState("success");
         authState.setTxHash(txHash);
@@ -64,6 +69,11 @@ export const useStakingProcedures = ({
       },
       onLoading: () => {
         delegateState.setState("loading");
+        delegateState.setTxHash(undefined);
+        delegateState.setError(null);
+      },
+      onBroadcasting: () => {
+        delegateState.setState("broadcasting");
         delegateState.setTxHash(undefined);
         delegateState.setError(null);
       },

--- a/app/_services/stake/types.ts
+++ b/app/_services/stake/types.ts
@@ -16,4 +16,4 @@ export type BaseStakeProcedure = {
 
 export type StakeProcedureStep = "auth" | "delegate";
 
-export type StakeProcedureState = "idle" | "active" | "preparing" | "loading" | "success" | "error";
+export type StakeProcedureState = "idle" | "active" | "preparing" | "loading" | "broadcasting" | "success" | "error";

--- a/app/_services/unstake/hooks.tsx
+++ b/app/_services/unstake/hooks.tsx
@@ -40,6 +40,11 @@ export const useUnstakingProcedures = ({
         authState.setTxHash(undefined);
         authState.setError(null);
       },
+      onBroadcasting: () => {
+        authState.setState("broadcasting");
+        authState.setTxHash(undefined);
+        authState.setError(null);
+      },
       onSuccess: (txHash) => {
         authState.setState("success");
         authState.setTxHash(txHash);
@@ -59,6 +64,11 @@ export const useUnstakingProcedures = ({
       },
       onLoading: () => {
         undelegateState.setState("loading");
+        undelegateState.setTxHash(undefined);
+        undelegateState.setError(null);
+      },
+      onBroadcasting: () => {
+        undelegateState.setState("broadcasting");
         undelegateState.setTxHash(undefined);
         undelegateState.setError(null);
       },

--- a/app/_services/unstake/types.ts
+++ b/app/_services/unstake/types.ts
@@ -16,7 +16,7 @@ export type BaseUnstakeProcedure = {
 
 export type UnstakeProcedureStep = "auth" | "undelegate";
 
-export type UnstakeProcedureState = "idle" | "active" | "preparing" | "loading" | "success" | "error";
+export type UnstakeProcedureState = "idle" | "active" | "preparing" | "loading" | "broadcasting" | "success" | "error";
 
 export type UnbondingDelegation = {
   validatorAddress: string;


### PR DESCRIPTION
## Changes
Added the "Preparing transaction" CTA copy immediately when the CTA button is clicked, then it changes to "Proceed in wallet" when the BE is done and the wallet window has been opened.

## Note
@vince19972 We might not be able to add the "Broadcasting transaction" CTA copy because there's only one line of code (below) that controls the process from "Proceed to wallet" till it's successful / fails. cc @eddy-apybara 

<-- Proceed in wallet starts here -->
`const res = await client.signAndBroadcast(address, msgs, fee);`
<-- Broadcast is completed here -->

