### PR TITLE
chore: revise compound frequency

### DIFF
--- a/app/_services/stakingOperator/utils.ts
+++ b/app/_services/stakingOperator/utils.ts
@@ -14,7 +14,8 @@ export const getCalculatedRewards = (amountStaked: string, rewardRate: number) =
   const daily = base / 365;
 
   const nextCompoundingDays = Math.ceil(1 / daily);
-  const nextCompoundingDate = moment().add(nextCompoundingDays, "d").toDate();
+  const nextCompoundingDaysByInterval = nextCompoundingDays % 2 !== 0 ? nextCompoundingDays + 1 : nextCompoundingDays;
+  const nextCompoundingDate = moment().add(nextCompoundingDaysByInterval, "d").toDate();
 
   return {
     percentage: numbro(rewardRate * 100).format({
@@ -23,7 +24,7 @@ export const getCalculatedRewards = (amountStaked: string, rewardRate: number) =
     daily,
     monthly: base / 12,
     yearly: base,
-    nextCompoundingDays,
-    nextCompounding: nextCompoundingDays > 100 ? ">100d" : getTimeDiffInSingleString(nextCompoundingDate),
+    nextCompoundingDays: nextCompoundingDaysByInterval,
+    nextCompounding: nextCompoundingDaysByInterval > 100 ? ">100d" : getTimeDiffInSingleString(nextCompoundingDate),
   };
 };

--- a/app/_utils/time.ts
+++ b/app/_utils/time.ts
@@ -6,17 +6,17 @@ export const getTimeDiffInSingleString = (time?: string | Date) => {
   const diff = getTimeDiffFromNow(time);
 
   if (diff.asMinutes() <= 1) {
-    return `${diff.seconds()}s`;
+    return `${diff.asSeconds()}s`;
   } else if (diff.asHours() <= 1) {
-    return `${diff.minutes()}m`;
+    return `${diff.asMinutes()}m`;
   } else if (diff.asHours() <= 24) {
     let result = `${Math.floor(diff.asHours())}h`;
     if (diff.minutes() > 0) {
-      result += ` ${diff.minutes()}m`;
+      result += ` ${diff.asMinutes()}m`;
     }
     return result;
   } else {
-    return `${diff.days()}d`;
+    return `${diff.asDays()}d`;
   }
 };
 


### PR DESCRIPTION
## To review
Besides from testing with your own wallet, here are the screenshots I tested with static fake `stakedAmount` value. 
- ⚠️ Please only focus on the "Next compounding" days value; other values in the widget don't change with the fake `stakeAmount` value.

1. When amount is `0.1`
![Screenshot 2024-05-24 at 2 12 37 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/dc7c7ae9-587a-4f57-b962-9a0dfd6a9ad9)

2. When amount is `1`
![Screenshot 2024-05-24 at 2 12 22 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/2999be23-3ef6-48ec-a268-50bbede40833)

3. When amount is `10`
![Screenshot 2024-05-24 at 2 12 08 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/cfa51a19-29c3-47e2-a1c4-e7b557b743bb)

4. When amount is `100`
![Screenshot 2024-05-24 at 2 11 22 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/206aa05e-48d1-4025-af96-fb429f5438a5)

5. When amount is `1000`
![Screenshot 2024-05-24 at 2 11 11 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/4ec8ee29-eec9-4f9a-bb91-b13e0bcfb257)

6. When amount is `10000`
![Screenshot 2024-05-24 at 2 11 00 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/038f38a5-0dee-4649-b0a5-ed3bf7ca77e8)

## Notes
This PR also fixes a days formatting issue. This screenshot shows on the current staging version, when `stakedAmount` is `100`, the "Next compounding" days is "3d left", but it should be "34d left".
![Screenshot 2024-05-24 at 2 23 12 PM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/35579c0b-8ba0-44ce-b632-8057c4bb6aa0)
