### PR TITLE
fix: ustake buffer amount validation

### DIFF
--- a/app/_contexts/RedelegatingContext/hooks.tsx
+++ b/app/_contexts/RedelegatingContext/hooks.tsx
@@ -1,4 +1,5 @@
 import type { RedelegatingStates } from "./types";
+import BigNumber from "bignumber.js";
 import { useShell } from "../ShellContext";
 import { useWallet } from "../WalletContext";
 import { useWalletBalance } from "../../_services/wallet/hooks";
@@ -23,7 +24,8 @@ export const useRedelegateValidation = ({
     amount,
     min: "0",
     max: balanceData,
-    buffer,
+    bufferValidationAmount: BigNumber(amount).plus(buffer).toString(),
+    bufferValidationMax: balanceData,
   });
 
   const ctaValidation = getBasicRedelegateCtaValidation({

--- a/app/_contexts/StakingContext/hooks.tsx
+++ b/app/_contexts/StakingContext/hooks.tsx
@@ -1,4 +1,5 @@
 import type { StakingStates } from "./types";
+import BigNumber from "bignumber.js";
 import { useShell } from "../../_contexts/ShellContext";
 import { useWallet } from "../../_contexts/WalletContext";
 import { useWalletBalance } from "../../_services/wallet/hooks";
@@ -17,7 +18,8 @@ export const useStakeAmountInputValidation = ({ inputAmount }: { inputAmount: St
     amount: inputAmount,
     min: "0",
     max: balanceData,
-    buffer,
+    bufferValidationAmount: BigNumber(inputAmount).plus(buffer).toString(),
+    bufferValidationMax: balanceData,
   });
   const ctaValidation = getBasicTxCtaValidation({
     amountValidation,

--- a/app/_contexts/UnstakingContext/hooks.tsx
+++ b/app/_contexts/UnstakingContext/hooks.tsx
@@ -1,10 +1,9 @@
 import type { UnstakingStates } from "./types";
 import { useShell } from "../ShellContext";
 import { useWallet } from "../WalletContext";
-import { getRequiredBalance } from "@/app/_services/unstake";
-import { getBasicAmountValidation, getBasicTxCtaValidation } from "../../_utils/transaction";
-import { defaultNetwork } from "../../consts";
 import { useWalletBalance } from "@/app/_services/wallet/hooks";
+import { getBasicAmountValidation, getBasicTxCtaValidation } from "../../_utils/transaction";
+import { defaultNetwork, requiredBalanceUnstakingByNetwork } from "../../consts";
 
 export const useUnstakeAmountInputValidation = ({
   inputAmount,
@@ -21,8 +20,8 @@ export const useUnstakeAmountInputValidation = ({
     amount: inputAmount,
     min: "0",
     max: stakedBalance,
-    walletBalance: balanceData,
-    buffer: getRequiredBalance({ network: network || defaultNetwork }),
+    bufferValidationAmount: requiredBalanceUnstakingByNetwork[network || defaultNetwork].toString(),
+    bufferValidationMax: balanceData,
   });
   const ctaValidation = getBasicTxCtaValidation({
     amountValidation,

--- a/app/_services/unstake/index.ts
+++ b/app/_services/unstake/index.ts
@@ -1,7 +1,0 @@
-import type { Network } from "../../types";
-import BigNumber from "bignumber.js";
-import { requiredBalanceUnstakingByNetwork } from "../../consts";
-
-export const getRequiredBalance = ({ network }: { network: Network }) => {
-  return BigNumber(requiredBalanceUnstakingByNetwork[network]).toString();
-};

--- a/app/_utils/transaction.ts
+++ b/app/_utils/transaction.ts
@@ -6,14 +6,14 @@ export const getBasicAmountValidation = ({
   amount,
   min,
   max,
-  walletBalance,
-  buffer,
+  bufferValidationAmount,
+  bufferValidationMax,
 }: {
   amount?: string;
   min?: string;
   max?: string;
-  walletBalance?: string;
-  buffer?: string;
+  bufferValidationAmount?: string;
+  bufferValidationMax?: string;
 }): BasicAmountValidationResult => {
   if (!amount || amount === "" || amount === "0") return "empty";
 
@@ -28,10 +28,11 @@ export const getBasicAmountValidation = ({
   if (max && parsedAmount.isGreaterThan(max)) {
     return "exceeded";
   }
-  if (!walletBalance && buffer && max && parsedAmount.plus(buffer).isGreaterThan(max)) {
-    return "bufferExceeded";
-  }
-  if (walletBalance && buffer && parsedAmount.plus(buffer).isGreaterThan(walletBalance)) {
+  if (
+    bufferValidationAmount &&
+    bufferValidationMax &&
+    BigNumber(bufferValidationAmount).isGreaterThan(bufferValidationMax)
+  ) {
     return "bufferExceeded";
   }
 


### PR DESCRIPTION
## Description
On [staging](https://staking-xyz-widget-git-staging-apybara.vercel.app/unstake?network=celestiatestnet3&currency=TIA), the unstaking CTA incorrectly shows "Insufficient amount for fees" when my wallet balance is over `0.03` ([my wallet balance is `3.79`](https://www.mintscan.io/celestia-testnet/address/celestia1gd28202j5nkdy38m7ad0djzsmwjvqksvu5gp5q)).

![Screenshot 2024-05-26 at 10 13 38 AM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/fd2f5881-49ed-47b8-8413-255f818166d0)

## Changes
This PR should fix the issue. See following screenshots for comparison (left side is this PR, right side is staging):

![Screenshot 2024-05-26 at 9 57 01 AM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/fc7685f1-a67b-4da2-b597-72b952e7c86a)
![Screenshot 2024-05-26 at 9 56 48 AM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/70afb184-d796-42cb-ac0e-5f7e56d8df06)
![Screenshot 2024-05-26 at 9 57 42 AM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/a69812ca-598b-4d1a-b4b2-ac9f08b6faee)

Locally, I also tested the validation with static `0.03` and `0.02` wallet balance:

![Screenshot 2024-05-26 at 10 01 01 AM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/e9031e16-c46f-42a9-ae91-b30553c31199)
![Screenshot 2024-05-26 at 10 00 44 AM](https://github.com/Apybara/staking-xyz-widget/assets/14227221/18264bb1-ef89-448a-bcaf-7c97e1a4f195)

## To review
- Make sure unstake CTA validation works as expected
- Make sure this PR doesn't break CTA validation on stake page