### PR TITLE
fix: minor redirect issue

### DIFF
--- a/app/_contexts/WidgetContext/hooks.tsx
+++ b/app/_contexts/WidgetContext/hooks.tsx
@@ -34,7 +34,7 @@ export const useWidgetRouterGate = ({ status, setStates }: WidgetStates) => {
     }
 
     setStates({ status: "loaded" });
-  }, [pathname, connectionStatus]);
+  }, [pathname, connectionStatus, status]);
 
   // Redirect to the default network if the current network is disabled on mobile
   useEffect(() => {


### PR DESCRIPTION
## Description
On production site, a direct visit to the [rewards](https://www.staking.xyz/rewards?network=celestiatestnet&currency=TIA) page or [activity](https://www.staking.xyz/activity?network=celestiatestnet&currency=TIA) page when the wallet is disconnected would result in a infinite loading state. 

## Steps to reproduce
1. [On production site](https://www.staking.xyz/), make sure wallet is disconnected
2. Directly visit the [rewards](https://www.staking.xyz/rewards?network=celestiatestnet&currency=TIA) page or [activity](https://www.staking.xyz/activity?network=celestiatestnet&currency=TIA) page, and you should see the issue

## To review
- Reproduce the steps above and you should be redirected to home page when disconnected