### PR TITLE
refactor: consolidate celestia & cosmosHub APIs

### DIFF
--- a/app/_services/cosmos/hooks.tsx
+++ b/app/_services/cosmos/hooks.tsx
@@ -21,8 +21,8 @@ import {
   getRedelegateValidatorMessages,
   getWithdrawRewardsMessage,
   getWithdrawRewardsValidatorMessages,
-} from "../stakingOperator/celestia";
-import { useCelestiaAddressAuthCheck } from "../stakingOperator/celestia/hooks";
+} from "../stakingOperator/cosmos";
+import { useCosmosAddressAuthCheck } from "../stakingOperator/cosmos/hooks";
 import {
   cosmosNetworkVariants,
   networkInfo,
@@ -44,8 +44,6 @@ import { getDenomValueFromCoin, getIsCosmosNetwork } from "./utils";
 import { getSigningClient, getGrantingMessages, getEstimatedGas, getFee } from ".";
 import Tooltip from "@/app/_components/Tooltip";
 import { Icon } from "@/app/_components/Icon";
-
-import * as StakeStyle from "@/app/(root)/stake/_components/stake.css";
 
 export const useCosmosUnstakingProcedures = ({
   amount,
@@ -79,7 +77,7 @@ export const useCosmosUnstakingProcedures = ({
   //   data: authCheck,
   //   isLoading,
   //   refetch,
-  // } = useCelestiaAddressAuthCheck({ network, address: address || undefined });
+  // } = useCosmosAddressAuthCheck({ network, address: address || undefined });
 
   // const authTx = useCosmosBroadcastAuthzTx({
   //   client: cosmosSigningClient || null,
@@ -278,7 +276,7 @@ export const useCosmosStakingProcedures = ({
   //   data: authCheck,
   //   isLoading,
   //   refetch,
-  // } = useCelestiaAddressAuthCheck({ network, address: address || undefined });
+  // } = useCosmosAddressAuthCheck({ network, address: address || undefined });
 
   // const cosmosAuthTx = useCosmosBroadcastAuthzTx({
   //   client: cosmosSigningClient || null,
@@ -732,7 +730,7 @@ export const useCosmosRedelegatingProcedures = ({
   //   data: authCheck,
   //   isLoading,
   //   refetch,
-  // } = useCelestiaAddressAuthCheck({ network, address: address || undefined });
+  // } = useCosmosAddressAuthCheck({ network, address: address || undefined });
 
   // const cosmosAuthTx = useCosmosBroadcastAuthzTx({
   //   client: cosmosSigningClient || null,

--- a/app/_services/stakingOperator/cosmos/hooks.tsx
+++ b/app/_services/stakingOperator/cosmos/hooks.tsx
@@ -7,7 +7,7 @@ import { fromUnixTime } from "date-fns";
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { serverUrlByNetwork, stakingOperatorUrlByNetwork } from "../../../consts";
 import { getTimeDiffInSingleUnits } from "../../../_utils/time";
-import { getCoinValueFromDenom } from "../../cosmos/utils";
+import { getCoinValueFromDenom, getIsCosmosNetwork } from "../../cosmos/utils";
 import { getCalculatedRewards, getLastOffset } from "../utils";
 import {
   getAddressAuthCheck,
@@ -21,12 +21,11 @@ import {
   getServerStatus,
   getExternalDelegations,
 } from ".";
-import numbro from "numbro";
 
-export const useCelestiaAddressAuthCheck = ({ address, network }: { address?: string; network: Network | null }) => {
+export const useCosmosAddressAuthCheck = ({ address, network }: { address?: string; network: Network | null }) => {
   const { data, isLoading, error, refetch } = useQuery({
-    enabled: !!address && getIsCelestiaNetwork(network),
-    queryKey: ["celestiaAddressAuthCheck", address, network],
+    enabled: !!address && getIsCosmosNetwork(network || ""),
+    queryKey: ["cosmosAddressAuthCheck", address, network],
     queryFn: () =>
       getAddressAuthCheck({ apiUrl: stakingOperatorUrlByNetwork[network || "celestia"], address: address || "" }),
     refetchOnWindowFocus: true,
@@ -35,10 +34,10 @@ export const useCelestiaAddressAuthCheck = ({ address, network }: { address?: st
   return { data, isLoading, error, refetch };
 };
 
-export const useCelestiaDelegations = ({ address, network }: { address?: string; network: Network | null }) => {
+export const useCosmosDelegations = ({ address, network }: { address?: string; network: Network | null }) => {
   const { data, isLoading, error, refetch } = useQuery({
-    enabled: !!address && getIsCelestiaNetwork(network),
-    queryKey: ["celestiaDelegations", address, network],
+    enabled: !!address && getIsCosmosNetwork(network || ""),
+    queryKey: ["cosmosDelegations", address, network],
     queryFn: () =>
       getDelegations({ apiUrl: stakingOperatorUrlByNetwork[network || "celestia"], address: address || "" }),
     refetchInterval: 90000,
@@ -49,16 +48,10 @@ export const useCelestiaDelegations = ({ address, network }: { address?: string;
   return { data, stakedBalance: !isLoading && !error ? stakedBalance : undefined, isLoading, error, refetch };
 };
 
-export const useCelestiaUnbondingDelegations = ({
-  address,
-  network,
-}: {
-  address?: string;
-  network: Network | null;
-}) => {
+export const useCosmosUnbondingDelegations = ({ address, network }: { address?: string; network: Network | null }) => {
   const { data, isLoading, error, refetch } = useQuery({
-    enabled: !!address && getIsCelestiaNetwork(network),
-    queryKey: ["celestiaUnbondingDelegations", address, network],
+    enabled: !!address && getIsCosmosNetwork(network || ""),
+    queryKey: ["cosmosUnbondingDelegations", address, network],
     queryFn: () =>
       getUnbondingDelegations({
         apiUrl: stakingOperatorUrlByNetwork[network || "celestia"],
@@ -73,11 +66,11 @@ export const useCelestiaUnbondingDelegations = ({
   return { data, formatted, isLoading, error, refetch };
 };
 
-export const useCelestiaExternalDelegations = ({ address, network }: { address?: string; network: Network | null }) => {
+export const useCosmosExternalDelegations = ({ address, network }: { address?: string; network: Network | null }) => {
   const castedNetwork = network || "celestia";
   const { data, isLoading, error, refetch } = useQuery({
-    enabled: !!address && getIsCelestiaNetwork(network),
-    queryKey: ["celestiaExternalDelegations", address, network],
+    enabled: !!address && getIsCosmosNetwork(network || ""),
+    queryKey: ["cosmosExternalDelegations", address, network],
     queryFn: () =>
       getExternalDelegations({ apiUrl: stakingOperatorUrlByNetwork[castedNetwork], address: address || "" }),
     refetchOnWindowFocus: true,
@@ -93,7 +86,7 @@ export const useCelestiaExternalDelegations = ({ address, network }: { address?:
   };
 };
 
-export const useCelestiaAddressActivity = ({
+export const useCosmosAddressActivity = ({
   network,
   address,
   offset,
@@ -107,7 +100,7 @@ export const useCelestiaAddressActivity = ({
     T.AddressActivityResponse | null,
     T.AddressActivityResponse
   >({
-    enabled: !!address && getIsCelestiaNetwork(network),
+    enabled: !!address && getIsCosmosNetwork(network || ""),
     queryKey: ["addressActivity", address, offset, limit, filterKey, network],
     queryFn: () => {
       if (!address) return Promise.resolve(null);
@@ -170,12 +163,12 @@ export const useCelestiaAddressActivity = ({
   };
 };
 
-export const useCelestiaAddressRewards = ({ network, address }: { network: Network | null; address?: string }) => {
+export const useCosmosAddressRewards = ({ network, address }: { network: Network | null; address?: string }) => {
   const { data, error, status, isLoading, isFetching, refetch } = useQuery<
     T.AddressRewardsResponse | null,
     T.AddressRewardsResponse
   >({
-    enabled: !!address && getIsCelestiaNetwork(network),
+    enabled: !!address && getIsCosmosNetwork(network || ""),
     queryKey: ["addressRewards", address, network],
     queryFn: () => {
       if (!address) return Promise.resolve(null);
@@ -202,7 +195,7 @@ export const useCelestiaAddressRewards = ({ network, address }: { network: Netwo
   };
 };
 
-export const useCelestiaAddressRewardsHistory = ({
+export const useCosmosAddressRewardsHistory = ({
   network,
   address,
   offset,
@@ -215,7 +208,7 @@ export const useCelestiaAddressRewardsHistory = ({
     T.AddressRewardsHistoryResponse | null,
     T.AddressRewardsHistoryResponse
   >({
-    enabled: !!address && getIsCelestiaNetwork(network),
+    enabled: !!address && getIsCosmosNetwork(network || ""),
     queryKey: ["addressRewardsHistory", address, offset, limit, network],
     queryFn: () => {
       if (!address) return Promise.resolve(null);
@@ -270,10 +263,10 @@ export const useCelestiaAddressRewardsHistory = ({
   };
 };
 
-export const useCelestiaReward = ({ network, amount }: { network: Network | null; amount: string }) => {
+export const useCosmosReward = ({ network, amount }: { network: Network | null; amount: string }) => {
   const { data, isLoading, isRefetching, error, refetch } = useQuery({
-    enabled: getIsCelestiaNetwork(network),
-    queryKey: ["celestiaReward", network, amount],
+    enabled: getIsCosmosNetwork(network || ""),
+    queryKey: ["cosmosReward", network, amount],
     queryFn: () => getNetworkReward({ apiUrl: stakingOperatorUrlByNetwork[network || "celestia"] }),
     refetchInterval: 600000, // 10 minutes
     refetchOnWindowFocus: true,
@@ -284,10 +277,10 @@ export const useCelestiaReward = ({ network, amount }: { network: Network | null
   return { data, rewards, isLoading: isLoading || isRefetching, error, refetch };
 };
 
-export const useCelestiaStatus = ({ network }: { network: Network | null }) => {
+export const useCosmosStatus = ({ network }: { network: Network | null }) => {
   const { data, isLoading, isRefetching, error, refetch } = useQuery({
-    enabled: getIsCelestiaNetwork(network),
-    queryKey: ["celestiaStatus", network],
+    enabled: getIsCosmosNetwork(network || ""),
+    queryKey: ["cosmosStatus", network],
     queryFn: () => getNetworkStatus({ apiUrl: stakingOperatorUrlByNetwork[network || "celestia"] }),
     refetchOnWindowFocus: true,
     refetchInterval: 180000,
@@ -296,10 +289,10 @@ export const useCelestiaStatus = ({ network }: { network: Network | null }) => {
   return { data, isLoading, isRefetching, error, refetch };
 };
 
-export const useCelestiaServerStatus = ({ network }: { network: Network | null }) => {
+export const useCosmosServerStatus = ({ network }: { network: Network | null }) => {
   const { data, isLoading, isRefetching, error, refetch } = useQuery({
-    enabled: getIsCelestiaNetwork(network),
-    queryKey: ["celestiaServerStatus", network],
+    enabled: getIsCosmosNetwork(network || ""),
+    queryKey: ["cosmosServerStatus", network],
     queryFn: () => getServerStatus({ apiUrl: serverUrlByNetwork[network || "celestia"] }),
     refetchOnWindowFocus: true,
     refetchInterval: 180000,
@@ -336,6 +329,3 @@ const useFormattedUnbondingDelegations = (
 
   return formattedDelegations;
 };
-
-const getIsCelestiaNetwork = (network: Network | null) => network === "celestia" || network === "celestiatestnet3";
-const getIsCosmoshubNetwork = (network: Network | null) => network === "cosmoshub" || network === "cosmoshubtestnet";

--- a/app/_services/stakingOperator/cosmos/index.ts
+++ b/app/_services/stakingOperator/cosmos/index.ts
@@ -1,6 +1,6 @@
-import { fetchData } from "@/app/_utils/fetch";
+import type { Network } from "../../../types";
 import type * as T from "../types";
-import { getCoinValueFromDenom } from "../../cosmos/utils";
+import { fetchData } from "@/app/_utils/fetch";
 
 export const getAddressAuthCheck = async ({ apiUrl, address }: T.BaseParams) => {
   const res: T.AuthCheckResponse = await fetchData(`${apiUrl}address/check/${address}`);
@@ -171,3 +171,6 @@ export const getRedelegateValidatorMessages = (operatorMessage: T.DecodedRedeleg
       amount: msg.amount,
     }));
 };
+
+export const getIsCelestia = (network: Network | null) => network === "celestia" || network === "celestiatestnet3";
+export const getIsCosmosHub = (network: Network | null) => network === "cosmoshub" || network === "cosmoshubtestnet";

--- a/app/_services/stakingOperator/hooks.tsx
+++ b/app/_services/stakingOperator/hooks.tsx
@@ -3,26 +3,20 @@ import * as T from "./types";
 import { useEffect, useState } from "react";
 import { useShell } from "../../_contexts/ShellContext";
 import { useWallet } from "../../_contexts/WalletContext";
-import {
-  useCelestiaDelegations,
-  useCelestiaUnbondingDelegations,
-  useCelestiaAddressActivity,
-  useCelestiaAddressRewardsHistory,
-  useCelestiaReward,
-  useCelestiaAddressRewards,
-  useCelestiaStatus,
-  useCelestiaServerStatus,
-  useCelestiaExternalDelegations,
-} from "../stakingOperator/celestia/hooks";
+import { getIsCelestia, getIsCosmosHub } from "./cosmos";
+import * as cosmos from "../stakingOperator/cosmos/hooks";
 
 export const useUnbondingDelegations = () => {
   const { network } = useShell();
   const { address } = useWallet();
-  const celestia = useCelestiaUnbondingDelegations({
+  const celestia = cosmos.useCosmosUnbondingDelegations({
     network,
-    address: address && (network === "celestia" || network === "celestiatestnet3") ? address : undefined,
+    address: address && getIsCelestia(network) ? address : undefined,
   });
-  const cosmoshub = undefined;
+  const cosmoshub = cosmos.useCosmosUnbondingDelegations({
+    network,
+    address: address && getIsCosmosHub(network) ? address : undefined,
+  });
 
   switch (network) {
     case "celestia":
@@ -39,11 +33,14 @@ export const useUnbondingDelegations = () => {
 export const useExternalDelegations = () => {
   const { network } = useShell();
   const { address } = useWallet();
-  const celestia = useCelestiaExternalDelegations({
+  const celestia = cosmos.useCosmosExternalDelegations({
     network,
-    address: address && (network === "celestia" || network === "celestiatestnet3") ? address : undefined,
+    address: address && getIsCelestia(network) ? address : undefined,
   });
-  const cosmoshub = celestia; // @David change this when cosmos endpoints are ready
+  const cosmoshub = cosmos.useCosmosExternalDelegations({
+    network,
+    address: address && getIsCosmosHub(network) ? address : undefined,
+  });
 
   switch (network) {
     case "celestia":
@@ -60,11 +57,14 @@ export const useExternalDelegations = () => {
 export const useStakedBalance = () => {
   const { network } = useShell();
   const { address } = useWallet();
-  const celestia = useCelestiaDelegations({
+  const celestia = cosmos.useCosmosDelegations({
     network,
-    address: address && (network === "celestia" || network === "celestiatestnet3") ? address : undefined,
+    address: address && getIsCelestia(network) ? address : undefined,
   });
-  const cosmoshub = undefined;
+  const cosmoshub = cosmos.useCosmosDelegations({
+    network,
+    address: address && getIsCosmosHub(network) ? address : undefined,
+  });
 
   switch (network) {
     case "celestia":
@@ -108,14 +108,20 @@ export const useActivity = (defaultParams: T.AddressActivityPaginationParams | n
   const { address } = useWallet();
 
   const { offset, setOffset, limit, filterKey, setFilterKey } = useAddressActivityQueryParams(defaultParams);
-  const celestia = useCelestiaAddressActivity({
+  const celestia = cosmos.useCosmosAddressActivity({
     network,
-    address: address && (network === "celestia" || network === "celestiatestnet3") ? address : undefined,
+    address: address && getIsCelestia(network) ? address : undefined,
     offset,
     limit,
     filterKey,
   });
-  const cosmoshub = undefined;
+  const cosmoshub = cosmos.useCosmosAddressActivity({
+    network,
+    address: address && getIsCosmosHub(network) ? address : undefined,
+    offset,
+    limit,
+    filterKey,
+  });
 
   switch (network) {
     case "celestia":
@@ -145,14 +151,20 @@ export const useLastOffsetActivity = ({
 }: Omit<T.AddressActivityPaginationParams, "offset"> & { lastOffset: number }) => {
   const { network } = useShell();
   const { address } = useWallet();
-  const celestia = useCelestiaAddressActivity({
+  const celestia = cosmos.useCosmosAddressActivity({
     network,
-    address: address || undefined,
+    address: address && getIsCelestia(network) ? address : undefined,
     offset: lastOffset,
     limit,
     filterKey,
   });
-  const cosmoshub = undefined;
+  const cosmoshub = cosmos.useCosmosAddressActivity({
+    network,
+    address: address && getIsCosmosHub(network) ? address : undefined,
+    offset: lastOffset,
+    limit,
+    filterKey,
+  });
 
   switch (network) {
     case "celestia":
@@ -182,11 +194,14 @@ export const useAddressRewards = () => {
   const { network } = useShell();
   const { address } = useWallet();
 
-  const celestia = useCelestiaAddressRewards({
+  const celestia = cosmos.useCosmosAddressRewards({
     network,
-    address: address && (network === "celestia" || network === "celestiatestnet3") ? address : undefined,
+    address: address && getIsCelestia(network) ? address : undefined,
   });
-  const cosmoshub = undefined;
+  const cosmoshub = cosmos.useCosmosAddressRewards({
+    network,
+    address: address && getIsCosmosHub(network) ? address : undefined,
+  });
 
   switch (network) {
     case "celestia":
@@ -211,13 +226,18 @@ export const useRewardsHistory = () => {
   const { address } = useWallet();
 
   const { offset, setOffset, limit } = useAddressRewardsHistoryQueryParams();
-  const celestia = useCelestiaAddressRewardsHistory({
+  const celestia = cosmos.useCosmosAddressRewardsHistory({
     network,
-    address: address && (network === "celestia" || network === "celestiatestnet3") ? address : undefined,
+    address: address && getIsCelestia(network) ? address : undefined,
     offset,
     limit,
   });
-  const cosmoshub = undefined;
+  const cosmoshub = cosmos.useCosmosAddressRewardsHistory({
+    network,
+    address: address && getIsCosmosHub(network) ? address : undefined,
+    offset,
+    limit,
+  });
 
   switch (network) {
     case "celestia":
@@ -245,8 +265,14 @@ export const useNetworkReward = (args?: { defaultNetwork?: Network; amount?: str
   const { network } = useShell();
   const castedNetwork = defaultNetwork || network;
 
-  const celestiaRewards = useCelestiaReward({ network: castedNetwork, amount: amount || "0" });
-  const cosmoshubRewards = undefined;
+  const celestiaRewards = cosmos.useCosmosReward({
+    network: getIsCelestia(castedNetwork) ? castedNetwork : null,
+    amount: amount || "0",
+  });
+  const cosmoshubRewards = cosmos.useCosmosReward({
+    network: getIsCosmosHub(castedNetwork) ? castedNetwork : null,
+    amount: amount || "0",
+  });
 
   switch (castedNetwork) {
     case "celestia":
@@ -262,8 +288,8 @@ export const useNetworkReward = (args?: { defaultNetwork?: Network; amount?: str
 
 export const useNetworkStatus = (defaultNetwork?: string) => {
   const { network } = useShell();
-  const celestiaStatus = useCelestiaStatus({ network });
-  const cosmoshubStatus = undefined;
+  const celestiaStatus = cosmos.useCosmosStatus({ network: getIsCelestia(network) ? network : null });
+  const cosmoshubStatus = cosmos.useCosmosStatus({ network: getIsCosmosHub(network) ? network : null });
 
   switch (defaultNetwork || network) {
     case "celestia":
@@ -279,8 +305,8 @@ export const useNetworkStatus = (defaultNetwork?: string) => {
 
 export const useServerStatus = (defaultNetwork?: string) => {
   const { network } = useShell();
-  const celestiaStatus = useCelestiaServerStatus({ network });
-  const cosmoshubStatus = undefined;
+  const celestiaStatus = cosmos.useCosmosServerStatus({ network: getIsCelestia(network) ? network : null });
+  const cosmoshubStatus = cosmos.useCosmosServerStatus({ network: getIsCosmosHub(network) ? network : null });
 
   switch (defaultNetwork || network) {
     case "celestia":


### PR DESCRIPTION
## Changes
- Rename "celestia" staking operator queries and hooks to "cosmos" to be compatible with both Celestia and Cosmos Hub

## To review
- Check if Celestia mainnet and testnet data are shown correctly
- Check if Cosmos Hub network status (in the footer) are shown correctly
- ⚠️ Note that this PR only confirms the network status integration with Cosmos Hub. Other data (e.g., rewards, staked amount, etc) are expected to be broken.
- ⚠️ To review locally, make sure you add the following env vars:
  - `NEXT_PUBLIC_SERVER_API_COSMOSHUB="https://cosmos-staking-api.staking.xyz/"`
  - `NEXT_PUBLIC_SERVER_API_COSMOSHUB_TESTNET="https://test-cosmos-staking-api.staking.xyz/"`

## Notes
- @blakdave please help me review the staking operator file, making sure I didn't make any mistakes. Thanks!