### PR TITLE
chore: rm unnecessary amount in gas fee calc

### DIFF
--- a/app/_services/cosmos/hooks.tsx
+++ b/app/_services/cosmos/hooks.tsx
@@ -193,7 +193,6 @@ export const useCosmosUndelegate = ({
       const estimatedGas = await getEstimatedGas({ client, address, msgArray: undelegateMsgs });
       const fee = getFee({
         gasLimit: estimatedGas,
-        network: network || defaultNetwork,
         networkDenom: networkInfo[network || defaultNetwork].denom,
       });
 
@@ -373,7 +372,6 @@ const useCosmosBroadcastAuthzTx = ({
       const estimatedGas = await getEstimatedGas({ client, address, msgArray: grantingMsgs });
       const fee = getFee({
         gasLimit: estimatedGas,
-        network: network || defaultNetwork,
         networkDenom: networkInfo[network || defaultNetwork].denom,
       });
 
@@ -498,7 +496,6 @@ const useCosmosBroadcastDelegateTx = ({
       const estimatedGas = await getEstimatedGas({ client, address, msgArray: msgs });
       const fee = getFee({
         gasLimit: estimatedGas,
-        network: network || defaultNetwork,
         networkDenom: networkInfo[network || defaultNetwork].denom,
       });
 
@@ -647,7 +644,6 @@ export const useCosmosWithdrawRewards = ({
       const estimatedGas = await getEstimatedGas({ client, address, msgArray: undelegateMsgs });
       const fee = getFee({
         gasLimit: estimatedGas,
-        network: network || defaultNetwork,
         networkDenom: networkInfo[network || defaultNetwork].denom,
       });
 
@@ -865,7 +861,6 @@ const useCosmosBroadcastRedelegateTx = ({
       const estimatedGas = await getEstimatedGas({ client, address, msgArray: msgs });
       const fee = getFee({
         gasLimit: estimatedGas,
-        network: network || defaultNetwork,
         networkDenom: networkInfo[network || defaultNetwork].denom,
       });
 

--- a/app/_services/cosmos/index.ts
+++ b/app/_services/cosmos/index.ts
@@ -104,23 +104,11 @@ export const getEstimatedGas = async ({
   }
 };
 
-export const getFee = ({
-  gasLimit,
-  gasPrice,
-  network,
-  networkDenom,
-}: {
-  gasLimit?: number;
-  gasPrice?: number;
-  network: CosmosNetwork;
-  networkDenom: string;
-}) => {
+export const getFee = ({ gasLimit, networkDenom }: { gasLimit?: number; networkDenom: string }) => {
   if (!gasLimit) gasLimit = 200000;
-  if (!gasPrice) gasPrice = networkDefaultGasPrice[network] || 0.02;
 
-  const amount = ceil(new BigNumber(gasPrice).multipliedBy(gasLimit).toNumber());
   return {
-    amount: [coin(amount, networkDenom)],
+    amount: [coin(0, networkDenom)],
     gas: gasLimit.toString(),
   };
 };


### PR DESCRIPTION
## Objective
- Remove unnecessary Cosmos gas fee calculation on the FE so wallet can handle them

## To review
- Go through all tx flows to make sure txs are passing through

## Notes
- Related to https://github.com/Apybara/cosmos-fee-calc/issues/1
- Potentially fixes https://github.com/Apybara/staking-xyz-widget/issues/283