### PR TITLE
fix: prevent closing dialog when processing tx

### DIFF
--- a/app/(root)/import/_components/RedelegatingProcedureDialog.tsx
+++ b/app/(root)/import/_components/RedelegatingProcedureDialog.tsx
@@ -163,7 +163,10 @@ const getCheckedProcedures = (procedures: Array<RedelegateProcedure>) => {
   return procedures.filter((procedure) => procedure.state === "success");
 };
 const getHasLoadingProcedures = (procedures: Array<RedelegateProcedure>) => {
-  return procedures.some((procedure) => procedure.state === "loading");
+  return procedures.some(
+    (procedure) =>
+      procedure.state === "preparing" || procedure.state === "loading" || procedure.state === "broadcasting",
+  );
 };
 const getActiveProcedure = (procedures: Array<RedelegateProcedure>) => {
   return procedures.find((procedure) => procedure.state !== "success");

--- a/app/(root)/rewards/_components/ClaimingProcedureDialog.tsx
+++ b/app/(root)/rewards/_components/ClaimingProcedureDialog.tsx
@@ -146,7 +146,10 @@ const getCheckedProcedures = (procedures: Array<ClaimProcedure>) => {
   return procedures.filter((procedure) => procedure.state === "success");
 };
 const getHasLoadingProcedures = (procedures: Array<ClaimProcedure>) => {
-  return procedures.some((procedure) => procedure.state === "loading");
+  return procedures.some(
+    (procedure) =>
+      procedure.state === "preparing" || procedure.state === "loading" || procedure.state === "broadcasting",
+  );
 };
 const getActiveProcedure = (procedures: Array<ClaimProcedure>) => {
   return procedures.find((procedure) => procedure.state !== "success");

--- a/app/(root)/stake/_components/StakingProcedureDialog.tsx
+++ b/app/(root)/stake/_components/StakingProcedureDialog.tsx
@@ -159,7 +159,10 @@ const getCheckedProcedures = (procedures: Array<StakeProcedure>) => {
   return procedures.filter((procedure) => procedure.state === "success");
 };
 const getHasLoadingProcedures = (procedures: Array<StakeProcedure>) => {
-  return procedures.some((procedure) => procedure.state === "loading");
+  return procedures.some(
+    (procedure) =>
+      procedure.state === "preparing" || procedure.state === "loading" || procedure.state === "broadcasting",
+  );
 };
 const getActiveProcedure = (procedures: Array<StakeProcedure>) => {
   return procedures.find((procedure) => procedure.state !== "success");

--- a/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
+++ b/app/(root)/unstake/_components/UnstakingProcedureDialog.tsx
@@ -159,7 +159,10 @@ const getCheckedProcedures = (procedures: Array<UnstakeProcedure>) => {
   return procedures.filter((procedure) => procedure.state === "success");
 };
 const getHasLoadingProcedures = (procedures: Array<UnstakeProcedure>) => {
-  return procedures.some((procedure) => procedure.state === "loading");
+  return procedures.some(
+    (procedure) =>
+      procedure.state === "preparing" || procedure.state === "loading" || procedure.state === "broadcasting",
+  );
 };
 const getActiveProcedure = (procedures: Array<UnstakeProcedure>) => {
   return procedures.find((procedure) => procedure.state !== "success");


### PR DESCRIPTION
## Objective
Currently, if you click outside of the dialog when tx is during the preparing or broadcasting states, the dialog would be closed. It's a bug that needs to be fixed.

## To review
- When a tx flow is not completed (either failed or successful), the dialog should be closed by clicking outside of it