### PR TITLE
feat: implement input pad warnings

### DIFF
--- a/app/(root)/import/_components/RedelegateCTA.tsx
+++ b/app/(root)/import/_components/RedelegateCTA.tsx
@@ -30,8 +30,10 @@ export const RedelegateCTA = () => {
 const textMap: Record<RedelegatingStates["ctaState"], string> = {
   empty: "No amount provided",
   invalid: "Agree",
+  ineligible: "Below minimum",
   insufficient: "Below minimum",
   exceeded: "Insufficient balance",
+  aboveBalance: "Insufficient balance",
   bufferExceeded: "Insufficient amount for fees",
   disconnected: "Connect wallet",
   connecting: "Connecting",
@@ -41,8 +43,10 @@ const textMap: Record<RedelegatingStates["ctaState"], string> = {
 const buttonState: Record<RedelegatingStates["ctaState"], CTAButtonProps["state"]> = {
   empty: "disabled",
   invalid: "disabled",
+  ineligible: "disabled",
   insufficient: "disabled",
   exceeded: "disabled",
+  aboveBalance: "disabled",
   bufferExceeded: "disabled",
   disconnected: "default",
   connecting: "loading",
@@ -52,8 +56,10 @@ const buttonState: Record<RedelegatingStates["ctaState"], CTAButtonProps["state"
 const buttonVariant: Record<RedelegatingStates["ctaState"], CTAButtonProps["variant"]> = {
   empty: "tertiary",
   invalid: "tertiary",
+  ineligible: "tertiary",
   insufficient: "tertiary",
   exceeded: "tertiary",
+  aboveBalance: "tertiary",
   bufferExceeded: "tertiary",
   disconnected: "primary",
   connecting: "primary",

--- a/app/(root)/stake/_components/StakeAmountInputPad.tsx
+++ b/app/(root)/stake/_components/StakeAmountInputPad.tsx
@@ -5,11 +5,13 @@ import { useWalletBalance } from "../../../_services/wallet/hooks";
 import { AmountInputPad } from "../../../_components/AmountInputPad";
 import { useStaking } from "../../../_contexts/StakingContext";
 import { useStakeMaxAmountBuffer } from "@/app/_contexts/StakingContext/hooks";
+import { stakingTypeErrorMap } from "@/app/consts";
+import { BasicAmountValidationResult } from "@/app/_utils/transaction";
 
 export const StakeAmountInputPad = () => {
-  const { network } = useShell();
+  const { network, stakingType } = useShell();
   const { activeWallet, address } = useWallet();
-  const { amountInputPad, setStates } = useStaking();
+  const { amountInputPad, setStates, inputState } = useStaking();
   const { data: balanceData, isLoading: isBalanceLoading } = useWalletBalance({ address, network, activeWallet }) || {};
 
   const maxAmountBuffer = useStakeMaxAmountBuffer({ amount: balanceData || "0" });
@@ -23,6 +25,8 @@ export const StakeAmountInputPad = () => {
         setStates({ coinAmountInput: val });
       }}
       maxAmountBuffer={maxAmountBuffer}
+      isStakingType={!!stakingType}
+      error={stakingType ? stakingTypeErrorMap[inputState as BasicAmountValidationResult] : ""}
       {...amountInputPad}
     />
   );

--- a/app/(root)/stake/_components/StakeCTA.tsx
+++ b/app/(root)/stake/_components/StakeCTA.tsx
@@ -3,11 +3,15 @@ import type { StakingStates } from "../../../_contexts/StakingContext/types";
 import { useDialog } from "../../../_contexts/UIContext";
 import { useStaking } from "../../../_contexts/StakingContext";
 import { type CTAButtonProps, CTAButton } from "../../../_components/CTAButton";
+import { useShell } from "@/app/_contexts/ShellContext";
 
 export const StakeCTA = () => {
-  const { ctaState } = useStaking();
+  const { stakingType } = useShell();
+  const { ctaState, inputState } = useStaking();
   const { toggleOpen: toggleWalletConnectionDialog } = useDialog("walletConnection");
   const { toggleOpen: toggleStakingProcedureDialog } = useDialog("stakingProcedure");
+
+  const hasStakingTypeError = inputState !== "empty" && inputState !== "valid";
 
   return (
     <CTAButton
@@ -22,7 +26,7 @@ export const StakeCTA = () => {
         }
       }}
     >
-      {textMap[ctaState]}
+      {stakingType ? (hasStakingTypeError ? "Please input a valid amount" : textMap[ctaState]) : textMap[ctaState]}
     </CTAButton>
   );
 };
@@ -30,8 +34,10 @@ export const StakeCTA = () => {
 const textMap: Record<StakingStates["ctaState"], string> = {
   empty: "Enter amount",
   invalid: "Invalid amount",
+  ineligible: "Below minimum",
   insufficient: "Below minimum",
   exceeded: "Insufficient balance",
+  aboveBalance: "Insufficient balance",
   bufferExceeded: "Insufficient amount for fees",
   disconnected: "Connect wallet",
   connecting: "Connecting",
@@ -41,8 +47,10 @@ const textMap: Record<StakingStates["ctaState"], string> = {
 const buttonState: Record<StakingStates["ctaState"], CTAButtonProps["state"]> = {
   empty: "disabled",
   invalid: "disabled",
+  ineligible: "disabled",
   insufficient: "disabled",
   exceeded: "disabled",
+  aboveBalance: "disabled",
   bufferExceeded: "disabled",
   disconnected: "default",
   connecting: "loading",
@@ -52,8 +60,10 @@ const buttonState: Record<StakingStates["ctaState"], CTAButtonProps["state"]> = 
 const buttonVariant: Record<StakingStates["ctaState"], CTAButtonProps["variant"]> = {
   empty: "tertiary",
   invalid: "tertiary",
+  ineligible: "tertiary",
   insufficient: "tertiary",
   exceeded: "tertiary",
+  aboveBalance: "tertiary",
   bufferExceeded: "tertiary",
   disconnected: "primary",
   connecting: "primary",

--- a/app/(root)/unstake/_components/UnstakeCTA.tsx
+++ b/app/(root)/unstake/_components/UnstakeCTA.tsx
@@ -30,8 +30,10 @@ export const UnstakeCTA = () => {
 const textMap: Record<UnstakingStates["ctaState"], string> = {
   empty: "Enter amount",
   invalid: "Invalid amount",
+  ineligible: "Below minimum",
   insufficient: "Below minimum",
   exceeded: "Insufficient balance",
+  aboveBalance: "Insufficient balance",
   bufferExceeded: "Insufficient amount for fees",
   disconnected: "Connect wallet",
   connecting: "Connecting",
@@ -41,8 +43,10 @@ const textMap: Record<UnstakingStates["ctaState"], string> = {
 const buttonState: Record<UnstakingStates["ctaState"], CTAButtonProps["state"]> = {
   empty: "disabled",
   invalid: "disabled",
+  ineligible: "disabled",
   insufficient: "disabled",
   exceeded: "disabled",
+  aboveBalance: "disabled",
   bufferExceeded: "disabled",
   disconnected: "default",
   connecting: "loading",
@@ -52,8 +56,10 @@ const buttonState: Record<UnstakingStates["ctaState"], CTAButtonProps["state"]> 
 const buttonVariant: Record<UnstakingStates["ctaState"], CTAButtonProps["variant"]> = {
   empty: "tertiary",
   invalid: "tertiary",
+  ineligible: "tertiary",
   insufficient: "tertiary",
   exceeded: "tertiary",
+  aboveBalance: "tertiary",
   bufferExceeded: "tertiary",
   disconnected: "primary",
   connecting: "primary",

--- a/app/_components/AmountInputPad/RootAmountInputPad.tsx
+++ b/app/_components/AmountInputPad/RootAmountInputPad.tsx
@@ -6,8 +6,10 @@ import { Skeleton } from "../Skeleton";
 import { MaxButton } from "./MaxButton";
 import * as S from "./amountInputPad.css";
 import { useShell } from "@/app/_contexts/ShellContext";
+import { getIsAleoNetwork } from "@/app/_services/aleo/utils";
 
 export type RootAmountInputPadProps = {
+  className?: string;
   availableValue?: string;
   availabilityElement?: ReactNode;
   isAvailableValueLoading?: boolean;
@@ -16,9 +18,11 @@ export type RootAmountInputPadProps = {
   onClickMax: () => void;
   maxTooltip?: ReactNode;
   isMaxDisabled?: boolean;
+  error?: string;
 };
 
 export const RootAmountInputPad = ({
+  className,
   availableValue,
   availabilityElement,
   isAvailableValueLoading,
@@ -27,11 +31,13 @@ export const RootAmountInputPad = ({
   onClickMax,
   maxTooltip,
   isMaxDisabled,
+  error,
 }: RootAmountInputPadProps) => {
-  const { stakingType } = useShell();
+  const { network, stakingType } = useShell();
+  const isAleoNetwork = network && getIsAleoNetwork(network);
 
   return (
-    <div className={cn(S.amountInputPad)}>
+    <div className={cn(className, S.amountInputPad)}>
       {isAvailableValueLoading && (
         <div className={cn(S.topBar)}>
           <Skeleton height={24} width={100} />
@@ -48,8 +54,9 @@ export const RootAmountInputPad = ({
       )}
       <div className={cn(S.mainControlBox)}>
         <InputField {...inputField} />
-        {!stakingType && <CurrencyConversionTool {...currencyConversionTool} />}
+        {!isAleoNetwork && <CurrencyConversionTool {...currencyConversionTool} />}
       </div>
+      {!!stakingType && !!error && <span className={S.errorMessage}>{error}</span>}
     </div>
   );
 };

--- a/app/_components/AmountInputPad/amountInputPad.css.ts
+++ b/app/_components/AmountInputPad/amountInputPad.css.ts
@@ -71,6 +71,10 @@ export const amountInputPad = style({
   paddingBlockEnd: pxToRem(30),
 });
 
+export const stakingTypeWithNoError = style({
+  paddingBlockEnd: pxToRem(40),
+});
+
 export const topBar = style({
   display: "flex",
   justifyContent: "space-between",
@@ -130,4 +134,13 @@ export const secondaryAvailabilityText = style({
   fontSize: pxToRem(12),
   color: colors.black300,
   lineHeight: 1,
+});
+
+export const errorMessage = style({
+  fontSize: pxToRem(12),
+  color: colors.yellow900,
+  textAlign: "center",
+  whiteSpace: "nowrap",
+  display: "block",
+  marginBlockEnd: pxToRem(-16),
 });

--- a/app/_components/AmountInputPad/index.tsx
+++ b/app/_components/AmountInputPad/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+import cn from "classnames";
 import type { Currency } from "../../types";
 import type { ReactNode } from "react";
 import { useEffect, useMemo } from "react";
@@ -34,6 +35,8 @@ export type BaseAmountInputPadProps = {
   onSwap: () => void;
   maxAmountBuffer?: string;
   onMax: (maxVal?: string | undefined) => void;
+  isStakingType?: boolean;
+  error?: string;
 };
 
 export type AmountInputPadProps = BaseAmountInputPadProps & {
@@ -56,6 +59,8 @@ export const AmountInputPad = ({
   onSwap,
   maxAmountBuffer,
   onMax,
+  isStakingType,
+  error,
 }: AmountInputPadProps) => {
   const { network, stakingType } = useShell();
   const castedNetwork = network || defaultNetwork;
@@ -102,6 +107,7 @@ export const AmountInputPad = ({
 
   return (
     <RootAmountInputPad
+      className={cn({ [S.stakingTypeWithNoError]: isStakingType && !error })}
       availableValue={availableValue}
       availabilityElement={
         <AvailabilityElement
@@ -151,7 +157,7 @@ export const AmountInputPad = ({
         );
       }}
       maxTooltip={
-        type === "stake" && !stakingType ? (
+        type === "stake" ? (
           <Tooltip
             className={S.topBarTooltip}
             trigger={<Icon name="info" />}
@@ -163,6 +169,7 @@ export const AmountInputPad = ({
         type === "stake" &&
         BigNumber(availableValue || "0").isLessThanOrEqualTo(requiredBalanceStakingByNetwork[castedNetwork])
       }
+      error={error}
     />
   );
 };

--- a/app/_utils/transaction.ts
+++ b/app/_utils/transaction.ts
@@ -3,12 +3,14 @@ import BigNumber from "bignumber.js";
 import { feeRatioByNetwork } from "../consts";
 
 export const getBasicAmountValidation = ({
+  isFirstTime,
   amount,
   min,
   max,
   bufferValidationAmount,
   bufferValidationMax,
 }: {
+  isFirstTime?: boolean;
   amount?: string;
   min?: string;
   max?: string;
@@ -23,7 +25,7 @@ export const getBasicAmountValidation = ({
     return "invalid";
   }
   if (min && parsedAmount.isLessThanOrEqualTo(min)) {
-    return "insufficient";
+    return isFirstTime ? "ineligible" : "insufficient";
   }
   if (max && parsedAmount.isGreaterThan(max)) {
     return "exceeded";
@@ -88,16 +90,20 @@ export type BasicAmountValidationResult =
   | "valid"
   | "empty"
   | "invalid"
+  | "ineligible"
   | "insufficient"
   | "exceeded"
-  | "bufferExceeded";
+  | "bufferExceeded"
+  | "aboveBalance";
 
 export type BasicTxCtaValidationResult =
   | "empty"
   | "invalid"
+  | "ineligible"
   | "insufficient"
   | "exceeded"
   | "bufferExceeded"
+  | "aboveBalance"
   | "disconnected"
   | "connecting"
   | "submittable";

--- a/app/consts.ts
+++ b/app/consts.ts
@@ -2,6 +2,7 @@ import type { Network, NetworkInfo, NetworkCurrency, WalletInfo, WalletType, Sta
 import CelestiaLogo from "./_assets/networks/celestia-logo.svg";
 import CosmosHubLogo from "./_assets/networks/cosmos-hub-logo.svg";
 import AleoLogo from "./_assets/networks/aleo-logo.svg";
+import { BasicAmountValidationResult } from "./_utils/transaction";
 
 export const NetworkVariants = ["cosmoshub", "cosmoshubtestnet", "celestia", "celestiatestnet3", "aleo"] as const;
 export const networkVariants = [...NetworkVariants];
@@ -173,6 +174,17 @@ export const networkDefaultStakingType: Record<Network, StakingType | null> = {
   cosmoshub: null,
   cosmoshubtestnet: null,
   aleo: "native",
+};
+
+export const stakingTypeErrorMap: Record<BasicAmountValidationResult, string> = {
+  empty: "",
+  invalid: "",
+  valid: "",
+  ineligible: "You need to stake at least 10,000 Credits to begin.",
+  insufficient: "You need to stake at least 1 Credit.",
+  exceeded: "Insufficient balance",
+  aboveBalance: "You are unstaking more than your staked balance.",
+  bufferExceeded: "Insufficient balance for fee",
 };
 
 export const CosmosWalletVariants = ["keplr", "keplrMobile", "leap", "leapMobile", "okx", "walletConnect"] as const;
@@ -348,6 +360,29 @@ export const requiredBalanceUnstakingByNetwork: Record<Network, number> = {
       ? Number(process.env.NEXT_PUBLIC_COSMOSHUBTESTNET_REQUIRED_BALANCE_UNSTAKING)
       : 0.03,
   aleo: 0, // TODO: Add Aleo required balance unstaking
+};
+
+export const minimumStakingAmountByNetwork: Record<Network, Record<StakingType, number | null>> = {
+  celestia: {
+    native: null,
+    liquid: null,
+  },
+  celestiatestnet3: {
+    native: null,
+    liquid: null,
+  },
+  cosmoshub: {
+    native: null,
+    liquid: null,
+  },
+  cosmoshubtestnet: {
+    native: null,
+    liquid: null,
+  },
+  aleo: {
+    native: 10000,
+    liquid: null,
+  },
 };
 
 export const unstakingPeriodByNetwork: Record<Network, string> = {


### PR DESCRIPTION
## Note
This is just for the Staking input pad, to avoid a very large PR. I've created [a ticket](https://github.com/Apybara/staking-xyz-widget/issues/337) for the unstaking input pad. 

## Question
- @vince19972 @eddy-apybara  How do we determine a first-time user? In this PR, I'm determining this by checking if the user has a staked balance (or if it's `0`) but I don't think this is ideal because of users that might unstake all their staked assets
- @vince19972 I've been stuck trying to modularize the error messages, especially the one that says the user has to stake a minimum of 10,000 credits. I'm trying to figure out how we can globalize the scope of the error messages so that we can use them for other networks that might have different minimum credits. Any ideas?