### PR TITLE
chore: temporarily disable leo wallet mobile

### DIFF
--- a/app/consts.ts
+++ b/app/consts.ts
@@ -206,6 +206,7 @@ export const walletsInfo: Record<WalletType, WalletInfo> = {
     logo: "/wallets/keplr.svg",
     downloadLink: undefined,
     devicesSupport: ["mobile"],
+    comingSoon: ["mobile"],
   },
   leap: {
     id: "leap",
@@ -220,6 +221,7 @@ export const walletsInfo: Record<WalletType, WalletInfo> = {
     logo: "/wallets/leap.svg",
     downloadLink: undefined,
     devicesSupport: ["mobile"],
+    comingSoon: ["mobile"],
   },
   okx: {
     id: "okx",
@@ -241,6 +243,7 @@ export const walletsInfo: Record<WalletType, WalletInfo> = {
     logo: "/wallets/leoWallet.svg",
     downloadLink: "https://www.leo.app/download",
     devicesSupport: ["desktop", "mobile"],
+    comingSoon: ["mobile"],
   },
   puzzle: {
     id: "puzzle",

--- a/app/types.ts
+++ b/app/types.ts
@@ -41,6 +41,7 @@ export type WalletInfo = {
   logo: string;
   downloadLink?: string;
   devicesSupport: Array<Device>;
+  comingSoon?: Array<Device>;
 };
 export type NetworkWalletType = {
   celestia: CosmosWalletType[];


### PR DESCRIPTION
## Reason
leo.app is currently not detecting the Leo Wallet mobile app. This means that, on our widget, it will always show the "Install" button whether the app is installed or not.

We're disabling this option with the "Coming soon" label till there's an available fix.

## Changes
Added the `comingSoon` field to the Wallets const, so that we can automate the "Coming soon" text for all networks as we deem fit