### PR TITLE
style: avoid header broken on narrow viewports

### DIFF
--- a/app/_components/Header/header.css.ts
+++ b/app/_components/Header/header.css.ts
@@ -7,14 +7,19 @@ export const header = style({
   containerType: "inline-size",
   containerName: headerContainer,
   display: "flex",
+  flexWrap: "wrap",
   justifyContent: "space-between",
   alignItems: "center",
+  gap: pxToRem(8),
   paddingInline: pxToRem(32),
   paddingBlock: pxToRem(21),
 
   "@media": {
     "screen and (max-width: 768px)": {
       paddingInline: pxToRem(20),
+    },
+    "screen and (max-width: 330px)": {
+      paddingInline: pxToRem(10),
     },
   },
 });
@@ -41,11 +46,15 @@ export const logoLigature = style({
 export const endBox = style({
   display: "flex",
   alignItems: "stretch",
+  flexWrap: "wrap",
   gap: pxToRem(20),
 
   "@container": {
     "(max-width: 480px)": {
       gap: pxToRem(16),
+    },
+    "(max-width: 330px)": {
+      gap: pxToRem(8),
     },
   },
 });


### PR DESCRIPTION
## To review
- Narrow the viewport, and the header layout should not be broken on standard mobile dimensions (between ~320px to ~780px)
- Narrow the viewport to under ~300px, and the header items should be wrapped to avoid broken layouts

## Notes
- Though the wrapped UI isn't the best under ~300px width, that's an edge scenario that we don't need to spend time to optimize.