### PR TITLE
chore: improve URL params and redirects

### DIFF
--- a/app/_utils/index.ts
+++ b/app/_utils/index.ts
@@ -1,3 +1,6 @@
+import type { Network, Currency } from "../types";
+import { networkCurrency, networkUrlParamRegex, currencyRegex } from "../consts";
+
 export const removeLeadingAndTrailingZeros = (val: string) => {
   // Remove leading zeros except in cases like "0.01"
   const noLeadingZeros = val.replace(/^0+(?!\.)/, "");
@@ -20,4 +23,29 @@ export const removeLeadingAndTrailingZeros = (val: string) => {
 
   // Otherwise, recombine the integer and non-empty decimal part
   return `${integerString}.${trimmedDecimalString}`;
+};
+
+export const getIsNetworkValid = (network?: string) => network && networkUrlParamRegex.test(network);
+export const getIsCurrencyValid = (currency?: string) => currencyRegex.test(currency || "");
+
+export const getIsNetworkCurrencyPairValid = (network?: string, currency?: string) => {
+  const isNetworkValid = getIsNetworkValid(network);
+  const isCurrencyValid = getIsCurrencyValid(currency);
+
+  if (!isNetworkValid || !isCurrencyValid) return false;
+
+  const upperCaseCurrency = (currency || "").toUpperCase();
+
+  switch (network as Network) {
+    case "celestia":
+      return networkCurrency.celestia === upperCaseCurrency;
+    case "celestiatestnet3":
+      return networkCurrency.celestiatestnet3 === upperCaseCurrency;
+    case "cosmoshub":
+      return networkCurrency.cosmoshub === upperCaseCurrency;
+    case "cosmoshubtestnet":
+      return networkCurrency.cosmoshubtestnet === upperCaseCurrency;
+    case "aleo":
+      return networkCurrency.aleo === upperCaseCurrency;
+  }
 };

--- a/app/_utils/routes.tsx
+++ b/app/_utils/routes.tsx
@@ -1,5 +1,7 @@
-import type { RouterStruct } from "../types";
+import type { Network, RouterStruct } from "../types";
 import { useSearchParams } from "next/navigation";
+import { defaultNetwork, networkIdToUrlParamAlias, networkUrlParamToId } from "../consts";
+import { getIsNetworkValid } from ".";
 
 export const getCurrentSearchParams = (searchParams: RouterStruct["searchParams"]) => {
   const { network, currency, device } = searchParams || {};
@@ -26,4 +28,37 @@ export const useLinkWithSearchParams = (page: string) => {
   const query = search ? `?${search}` : "";
 
   return `/${page}${query}`;
+};
+
+export const getNetworkParamFromValidAlias = (network: string) => {
+  if (getIsNetworkValid(network)) {
+    return {
+      network: networkUrlParamToId[network],
+      alias: networkIdToUrlParamAlias[network as Network],
+    };
+  }
+
+  if (/\b(celestiatestnet3|mocha-4|mocha4)\b/.test(network)) {
+    return {
+      network: networkUrlParamToId.celestiatestnet3,
+      alias: networkIdToUrlParamAlias.celestiatestnet3,
+    };
+  }
+  if (/\b(cosmoshub|cosmoshub-4)\b/.test(network)) {
+    return {
+      network: networkUrlParamToId.cosmoshub,
+      alias: networkIdToUrlParamAlias.cosmoshub,
+    };
+  }
+  if (/\b(cosmoshubtestnet|theta-testnet-001)\b/.test(network)) {
+    return {
+      network: networkUrlParamToId.cosmoshubtestnet,
+      alias: networkIdToUrlParamAlias.cosmoshubtestnet,
+    };
+  }
+
+  return {
+    network: defaultNetwork,
+    alias: networkIdToUrlParamAlias[defaultNetwork],
+  };
 };


### PR DESCRIPTION
## To review
- Randomly use incorrect currency and network params pairings, and the app should always redirect to a correct paring or fallback to default options. For example:
  - `network=cosm` should be redirected to `network=cosmoshub&currency=ATOM`
  - `network=celestia&currency=ATOM` should be redirected to `network=celestia&currency=TIA`
  - `network=cosmoshub&currency=TIA` should be redirected to `network=cosmoshub&currency=ATOM`