### PR TITLE
feat: preliminary integration of Aleo activity endpoint

### DIFF
--- a/app/(root)/activity/_components/ActivityTable.tsx
+++ b/app/(root)/activity/_components/ActivityTable.tsx
@@ -1,6 +1,12 @@
 "use client";
 import type { Network } from "../../../types";
-import type { ActivityItem } from "../../../_services/stakingOperator/types";
+import type { TabButtonProps } from "../../../_components/TabButton";
+import type {
+  ActivityItem,
+  AddressActivityPaginationParams,
+  AleoAddressActivityPaginationParams,
+  StandardAddressActivityPaginationParams,
+} from "../../../_services/stakingOperator/types";
 import BigNumber from "bignumber.js";
 import { useShell } from "../../../_contexts/ShellContext";
 import { Skeleton } from "../../../_components/Skeleton";
@@ -10,6 +16,7 @@ import { ErrorRetryModule } from "../../../_components/ErrorRetryModule";
 import { getPercentagedNumber } from "../../../_utils/number";
 import { getUTCStringFromUnixTimestamp, getUTCStringFromUnixTimeString } from "../../../_utils/time";
 import { useDynamicAssetValueFromCoin } from "../../../_utils/conversions/hooks";
+import { getIsAleoNetwork } from "../../../_services/aleo/utils";
 import { useActivity } from "../../../_services/stakingOperator/hooks";
 import { networkExplorerTx, defaultNetwork } from "../../../consts";
 import * as S from "./activity.css";
@@ -19,6 +26,7 @@ export const ActivityTable = () => {
   const { params, query } = useActivity(null) || {};
   const { offset, setOffset, limit, filterKey, setFilterKey } = params;
   const { formattedEntries, isLoading, error, disableNextPage, lastOffset, refetch } = query || {};
+  const tabs = useTabs({ filterKey, setFilterKey });
 
   if (isLoading) {
     return (
@@ -44,35 +52,7 @@ export const ActivityTable = () => {
 
   return (
     <>
-      <ListTable.Tabs
-        tabs={[
-          {
-            children: "All",
-            state: filterKey === "transactions" ? "highlighted" : "default",
-            onClick: () => setFilterKey("transactions"),
-          },
-          {
-            children: "Stake",
-            state: filterKey === "transactions_stake" ? "highlighted" : "default",
-            onClick: () => setFilterKey("transactions_stake"),
-          },
-          {
-            children: "Unstake",
-            state: filterKey === "transactions_unstake" ? "highlighted" : "default",
-            onClick: () => setFilterKey("transactions_unstake"),
-          },
-          {
-            children: "Claim",
-            state: filterKey === "transactions_rewards" ? "highlighted" : "default",
-            onClick: () => setFilterKey("transactions_rewards"),
-          },
-          // {
-          //   children: "Import",
-          //   state: filterKey === "transactions_redelegate" ? "highlighted" : "default",
-          //   onClick: () => setFilterKey("transactions_redelegate"),
-          // },
-        ]}
-      />
+      <ListTable.Tabs tabs={tabs} />
       {formattedEntries?.length ? (
         <ListTable.Pad>
           <ListTable.List>
@@ -140,6 +120,71 @@ const ListItem = ({
       </ListTable.ExternalLinkItemWrapper>
     </ListTable.Item>
   );
+};
+
+const useTabs = ({
+  filterKey,
+  setFilterKey,
+}: {
+  filterKey: AddressActivityPaginationParams["filterKey"];
+  setFilterKey: (key?: AddressActivityPaginationParams["filterKey"]) => void;
+}) => {
+  const { network } = useShell();
+  const isAleo = getIsAleoNetwork(network);
+
+  if (isAleo) {
+    return [
+      {
+        children: "All",
+        state: filterKey === "transactions" ? "highlighted" : "default",
+        onClick: () => setFilterKey(),
+      },
+      {
+        children: "Stake",
+        state: filterKey === "stake" ? "highlighted" : "default",
+        onClick: () => setFilterKey("stake"),
+      },
+      {
+        children: "Unstake",
+        state: filterKey === "unstake" ? "highlighted" : "default",
+        onClick: () => setFilterKey("unstake"),
+      },
+      {
+        children: "Withdraw",
+        state: filterKey === "claim" ? "highlighted" : "default",
+        onClick: () => setFilterKey("claim"),
+      },
+    ] as Array<TabButtonProps>;
+  }
+
+  const castedFilterKey = filterKey as StandardAddressActivityPaginationParams["filterKey"];
+  return [
+    {
+      children: "All",
+      state: castedFilterKey === "transactions" ? "highlighted" : "default",
+      onClick: () => setFilterKey("transactions"),
+    },
+    {
+      children: "Stake",
+      state: castedFilterKey === "transactions_stake" ? "highlighted" : "default",
+      onClick: () => setFilterKey("transactions_stake"),
+    },
+    {
+      children: "Unstake",
+      state: castedFilterKey === "transactions_unstake" ? "highlighted" : "default",
+      onClick: () => setFilterKey("transactions_unstake"),
+    },
+    {
+      children: "Claim",
+      state: castedFilterKey === "transactions_rewards" ? "highlighted" : "default",
+      onClick: () => setFilterKey("transactions_rewards"),
+    },
+    // {
+    //   children: "Import",
+    //   state: filterKey === "transactions_redelegate" ? "highlighted" : "default",
+    //   onClick: () => setFilterKey("transactions_redelegate"),
+    // },
+  ] as Array<TabButtonProps>;
 };
 
 const titleKey = {

--- a/app/(root)/unstake/_components/UnstakeInfoBox.tsx
+++ b/app/(root)/unstake/_components/UnstakeInfoBox.tsx
@@ -13,7 +13,7 @@ import { defaultNetwork, unstakingPeriodByNetwork } from "../../../consts";
 import * as S from "./unstake.css";
 
 export const UnstakeInfoBox = () => {
-  const { currency, coinPrice, network } = useShell();
+  const { currency, coinPrice, network, stakingType } = useShell();
 
   const { data: unbondingDelegations } = useUnbondingDelegations() || {};
   const { data: withdrawableData } = useWithdrawableAmount() || {};

--- a/app/_services/stakingOperator/aleo/hooks.tsx
+++ b/app/_services/stakingOperator/aleo/hooks.tsx
@@ -1,4 +1,4 @@
-import type { AleoNetwork, Network } from "../../../types";
+import type { AleoNetwork, Network, StakingType } from "../../../types";
 import type * as T from "../types";
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { serverUrlByNetwork, stakingOperatorUrlByNetwork } from "../../../consts";
@@ -25,7 +25,7 @@ export const useAleoAddressActivity = ({
   offset,
   limit,
   filterKey,
-}: T.AddressActivityPaginationParams & { network: Network | null; address?: string; refetchInterval?: number }) => {
+}: T.AleoAddressActivityPaginationParams & { network: Network | null; address?: string; refetchInterval?: number }) => {
   const queryClient = useQueryClient();
   const [hasInProgress, setHasInProgress] = useState(false);
   const isAleoNetwork = getIsAleoNetwork(network || "");
@@ -40,6 +40,7 @@ export const useAleoAddressActivity = ({
     queryFn: () => {
       if (!address) return Promise.resolve(null);
       return getAddressActivity({
+        tsType: "aleo",
         apiUrl: stakingOperatorUrlByNetwork[castedNetwork],
         address,
         offset,
@@ -60,6 +61,7 @@ export const useAleoAddressActivity = ({
         queryFn: () => {
           if (!address) return Promise.resolve(null);
           return getAddressActivity({
+            tsType: "aleo",
             apiUrl: stakingOperatorUrlByNetwork[castedNetwork],
             address,
             offset: nextOffset,
@@ -104,6 +106,7 @@ export const useAleoUnbondingDelegations = ({ address, network }: { address?: st
     isLoading: initialIsLoading,
     error: initialIsError,
   } = useAleoAddressActivity({
+    tsType: "aleo",
     network,
     address,
     filterKey: "unstake",
@@ -112,6 +115,7 @@ export const useAleoUnbondingDelegations = ({ address, network }: { address?: st
   }) || {};
   const { formattedEntries, isLoading, error } =
     useAleoAddressActivity({
+      tsType: "aleo",
       network,
       address,
       filterKey: "unstake",

--- a/app/_services/stakingOperator/aleo/index.ts
+++ b/app/_services/stakingOperator/aleo/index.ts
@@ -7,7 +7,7 @@ export const getAddressActivity = async ({
   offset,
   limit,
   filterKey,
-}: T.AddressActivityPaginationParams & T.BaseParams) => {
+}: T.AleoAddressActivityPaginationParams & T.BaseParams) => {
   const filterQuery = !!filterKey ? `&filterBy=type&filterKey=${filterKey}` : "";
 
   const res: T.AddressActivityResponse = await fetchData(

--- a/app/_services/stakingOperator/cosmos/hooks.tsx
+++ b/app/_services/stakingOperator/cosmos/hooks.tsx
@@ -75,7 +75,11 @@ export const useCosmosAddressActivity = ({
   offset,
   limit,
   filterKey,
-}: T.AddressActivityPaginationParams & { network: Network | null; address?: string; refetchInterval?: number }) => {
+}: T.StandardAddressActivityPaginationParams & {
+  network: Network | null;
+  address?: string;
+  refetchInterval?: number;
+}) => {
   const queryClient = useQueryClient();
   const [hasInProgress, setHasInProgress] = useState(false);
   const isCosmosNetwork = getIsCosmosNetwork(network || "");
@@ -90,6 +94,7 @@ export const useCosmosAddressActivity = ({
     queryFn: () => {
       if (!address) return Promise.resolve(null);
       return getAddressActivity({
+        tsType: "standard",
         apiUrl: stakingOperatorUrlByNetwork[castedNetwork],
         address,
         offset,
@@ -110,6 +115,7 @@ export const useCosmosAddressActivity = ({
         queryFn: () => {
           if (!address) return Promise.resolve(null);
           return getAddressActivity({
+            tsType: "standard",
             apiUrl: stakingOperatorUrlByNetwork[castedNetwork],
             address,
             offset: nextOffset,
@@ -154,6 +160,7 @@ export const useCosmosUnbondingDelegations = ({ address, network }: { address?: 
     isLoading: initialIsLoading,
     error: initialIsError,
   } = useCosmosAddressActivity({
+    tsType: "standard",
     network,
     address,
     filterKey: "transactions_unstake",
@@ -162,6 +169,7 @@ export const useCosmosUnbondingDelegations = ({ address, network }: { address?: 
   }) || {};
   const { formattedEntries, isLoading, error } =
     useCosmosAddressActivity({
+      tsType: "standard",
       network,
       address,
       filterKey: "transactions_unstake",

--- a/app/_services/stakingOperator/cosmos/index.ts
+++ b/app/_services/stakingOperator/cosmos/index.ts
@@ -13,7 +13,7 @@ export const getAddressActivity = async ({
   offset,
   limit,
   filterKey,
-}: T.AddressActivityPaginationParams & T.BaseParams) => {
+}: T.StandardAddressActivityPaginationParams & T.BaseParams) => {
   const filterQuery = !!filterKey ? `&filterBy=type&filterKey=${filterKey}` : "";
 
   const res: T.AddressActivityResponse = await fetchData(

--- a/app/_services/stakingOperator/types.ts
+++ b/app/_services/stakingOperator/types.ts
@@ -273,8 +273,13 @@ export type AddressActivityResponse = CommonEntriesResponse<
   hasMore?: boolean | null;
   totalEntries?: number | null;
 };
-export type AddressActivityPaginationParams = PaginationParams & {
-  filterKey:
+export type AddressActivityPaginationParams =
+  | StandardAddressActivityPaginationParams
+  | AleoAddressActivityPaginationParams;
+
+export type StandardAddressActivityPaginationParams = {
+  tsType: "standard";
+  filterKey?:
     | "stake"
     | "unstake"
     | "redelegate"
@@ -284,7 +289,23 @@ export type AddressActivityPaginationParams = PaginationParams & {
     | "transactions_rewards"
     | "transactions_redelegate"
     | null;
-};
+} & PaginationParams;
+
+export type AleoAddressActivityPaginationParams = {
+  tsType: "aleo";
+  filterKey?:
+    | "stake"
+    | "unstake"
+    | "claim"
+    | "native_stake"
+    | "native_unstake"
+    | "native_claim"
+    | "liquid_stake"
+    | "liquid_unstake"
+    | "liquid_claim"
+    | null;
+} & PaginationParams;
+
 export type ActivityItem = {
   id: string;
   type: "stake" | "unstake" | "rewards" | "redelegate" | "withdraw";


### PR DESCRIPTION
## Changes
Create distinct activity filter types for Aleo and Cosmos networks to accommodate different `filterKey` options on staking operator.

## Notes
This is just a preliminary FE preparation to unblock unstaking flow from completion. But Aleo activity pages and endpoints won't work until these staking operator tasks are done:
- https://github.com/Apybara/aleo-staking-api/issues/46
- https://github.com/Apybara/aleo-staking-api/issues/47
- https://github.com/Apybara/aleo-staking-api/issues/48