### PR TITLE
chore: avoid executing disabled queries

### DIFF
--- a/app/_services/aleo/hooks.tsx
+++ b/app/_services/aleo/hooks.tsx
@@ -43,11 +43,15 @@ import { aleoRestUrl } from "@/app/consts";
 export const useAleoAddressUnbondingStatus = ({ address, network }: { address?: string; network: Network | null }) => {
   const isAleoNetwork = getIsAleoNetwork(network || "");
   const isAleoAddressFormat = getIsAleoAddressFormat(address || "");
+  const shouldEnable = isAleoNetwork && isAleoAddressFormat;
 
   const { data, error, isLoading } = useQuery({
-    enabled: !!address && isAleoNetwork && isAleoAddressFormat,
+    enabled: shouldEnable,
     queryKey: ["aleoAddressUnbondingStatus", address, network],
-    queryFn: () => getAleoAddressUnbondingStatus({ apiUrl: aleoRestUrl, address: address || "" }),
+    queryFn: () => {
+      if (!shouldEnable) return null;
+      return getAleoAddressUnbondingStatus({ apiUrl: aleoRestUrl, address: address || "" });
+    },
     refetchInterval: 30000,
     refetchOnWindowFocus: true,
   });

--- a/app/_services/cosmos/hooks.tsx
+++ b/app/_services/cosmos/hooks.tsx
@@ -429,6 +429,7 @@ export const useCosmosSigningClient = ({ network, wallet }: { network: Network |
   const isCosmosWallet = !!wallet && getIsCosmosWalletType(wallet);
   const castedNetwork = (isCosmosNetwork ? network : defaultNetwork) as CosmosNetwork;
   const castedWallet = isCosmosWallet ? (wallet as CosmosWalletType) : null;
+  const shouldEnable = !!network && !!wallet && isCosmosNetwork;
 
   const offlineSignerGetter = useOfflineSignerGetter({ network: castedNetwork, wallet: castedWallet });
 
@@ -437,9 +438,12 @@ export const useCosmosSigningClient = ({ network, wallet }: { network: Network |
     isLoading,
     error,
   } = useQuery({
-    enabled: !!network && !!wallet && isCosmosNetwork,
+    enabled: shouldEnable,
     queryKey: ["cosmosSigningClient", network, wallet, !!offlineSignerGetter],
-    queryFn: () => getSigningClient({ network: network || undefined, getOfflineSigner: offlineSignerGetter }),
+    queryFn: () => {
+      if (!shouldEnable) return undefined;
+      return getSigningClient({ network: network || undefined, getOfflineSigner: offlineSignerGetter });
+    },
   });
 
   return { data: signingClient, isLoading, error };

--- a/app/_services/stakingOperator/aleo/hooks.tsx
+++ b/app/_services/stakingOperator/aleo/hooks.tsx
@@ -26,12 +26,15 @@ import { fromUnixTime } from "date-fns";
 import { useShell } from "@/app/_contexts/ShellContext";
 
 export const useAleoAddressRewards = ({ address, network }: { address: string; network: Network | null }) => {
-  const isAleoNetwork = getIsAleoNetwork(network || "");
+  const shouldEnable = getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address);
 
   const { data, isLoading, isRefetching, error, refetch } = useQuery({
-    enabled: !!address && isAleoNetwork,
+    enabled: shouldEnable,
     queryKey: ["aleoAddressRewards", network, address],
-    queryFn: () => getAddressRewards({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address }),
+    queryFn: () => {
+      if (!shouldEnable) return null;
+      return getAddressRewards({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address });
+    },
     refetchOnWindowFocus: true,
     refetchInterval: 15000,
   });
@@ -252,11 +255,15 @@ export const useAleoDelegatedValidator = ({ network, address }: { network: Netwo
 };
 
 export const useAleoValidatorDetails = ({ network, address }: { network: Network | null; address?: string }) => {
+  const shouldEnable = getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address || "");
+
   const { data, isLoading, isRefetching, error } = useQuery({
-    enabled: getIsAleoNetwork(network || "") && !!address,
+    enabled: shouldEnable,
     queryKey: ["aleoValidatorDetails", network, address],
-    queryFn: () =>
-      getValidatorDetails({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address: address || "" }),
+    queryFn: () => {
+      if (!shouldEnable) return null;
+      return getValidatorDetails({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address: address || "" });
+    },
   });
 
   return { data, isLoading, isRefetching, error };

--- a/app/_services/stakingOperator/cosmos/hooks.tsx
+++ b/app/_services/stakingOperator/cosmos/hooks.tsx
@@ -36,7 +36,7 @@ export const useCosmosDelegations = ({ address, network }: { address?: string; n
   const castedNetwork = (isCosmosNetwork ? network : "celestia") as CosmosNetwork;
 
   const { data, isLoading, error, refetch } = useQuery({
-    enabled: !!address && !!isCosmosNetwork,
+    enabled: !!network && !!address && !!isCosmosNetwork,
     queryKey: ["cosmosDelegations", address, network],
     queryFn: () => getDelegations({ apiUrl: stakingOperatorUrlByNetwork[castedNetwork], address: address || "" }),
     refetchInterval: 90000,

--- a/app/_services/stakingOperator/hooks.tsx
+++ b/app/_services/stakingOperator/hooks.tsx
@@ -69,11 +69,11 @@ export const useStakedBalance = () => {
   const { network } = useShell();
   const { address } = useWallet();
   const celestiaData = cosmos.useCosmosDelegations({
-    network,
+    network: getIsCelestia(network) ? network : null,
     address: address && getIsCelestia(network) ? address : undefined,
   });
   const cosmoshubData = cosmos.useCosmosDelegations({
-    network,
+    network: getIsCosmosHub(network) ? network : null,
     address: address && getIsCosmosHub(network) ? address : undefined,
   });
   const aleoData = aleo.useAleoAddressStakedBalance({


### PR DESCRIPTION
## Objective
Avoid these minor fetching errors

<img width="739" alt="Screenshot 2024-08-02 at 9 52 37 AM" src="https://github.com/user-attachments/assets/13154bc1-320c-4c80-9727-17f6546691cf">

![Screen Shot 2024-08-03 at 8 28 23 PM](https://github.com/user-attachments/assets/058ee299-5a34-42bc-bc89-8b94a97cf3f9)

![Screen Shot 2024-08-03 at 8 28 45 PM](https://github.com/user-attachments/assets/9dfc504e-b900-42b6-b3e0-b6b0c26a22f5)

## Note
I'm unsure why the `enabled` flag with `useQuery` hook for these two queries don't work though. Odd.