### PR TITLE
chore: prevent triggering disabled queries

### DIFF
--- a/app/_services/stakingOperator/aleo/hooks.tsx
+++ b/app/_services/stakingOperator/aleo/hooks.tsx
@@ -185,11 +185,15 @@ export const useAleoServerStatus = ({ network }: { network: Network | null }) =>
 };
 
 export const useAleoAddressBalance = ({ network, address }: { network: Network | null; address?: string }) => {
+  const shouldEnable = getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address || "");
+
   const { data, isLoading, isRefetching, error, refetch } = useQuery({
-    enabled: getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address || ""),
+    enabled: shouldEnable,
     queryKey: ["aleoAddressBalance", network, address],
-    queryFn: () =>
-      getAddressBalance({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address: address || "" }),
+    queryFn: () => {
+      if (!shouldEnable) return undefined;
+      return getAddressBalance({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address: address || "" });
+    },
     refetchOnWindowFocus: true,
     refetchInterval: 15000,
   });
@@ -198,11 +202,18 @@ export const useAleoAddressBalance = ({ network, address }: { network: Network |
 };
 
 export const useAleoAddressStakedBalance = ({ network, address }: { network: Network | null; address?: string }) => {
+  const shouldEnable = getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address || "");
+
   const { data, isLoading, isRefetching, error, refetch } = useQuery({
-    enabled: getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address || ""),
+    enabled: shouldEnable,
     queryKey: ["aleoAddressStakedBalance", network, address],
-    queryFn: () =>
-      getAddressStakedBalance({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address: address || "" }),
+    queryFn: () => {
+      if (!shouldEnable) return undefined;
+      return getAddressStakedBalance({
+        apiUrl: stakingOperatorUrlByNetwork[network || "aleo"],
+        address: address || "",
+      });
+    },
     refetchOnWindowFocus: true,
     refetchInterval: 15000,
   });
@@ -244,11 +255,15 @@ export const useAleoReward = ({ network, amount }: { network: Network | null; am
 };
 
 export const useAleoDelegatedValidator = ({ network, address }: { network: Network | null; address?: string }) => {
+  const shouldEnable = getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address || "");
+
   const { data, isLoading, isRefetching, error } = useQuery({
-    enabled: getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address || ""),
+    enabled: shouldEnable,
     queryKey: ["aleoDelegatedValidator", network, address],
-    queryFn: () =>
-      getAddressDelegation({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address: address || "" }),
+    queryFn: () => {
+      if (!shouldEnable) return undefined;
+      return getAddressDelegation({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"], address: address || "" });
+    },
   });
 
   return { data, isLoading, isRefetching, error };

--- a/app/_services/stakingOperator/cosmos/hooks.tsx
+++ b/app/_services/stakingOperator/cosmos/hooks.tsx
@@ -34,11 +34,15 @@ export const useCosmosAddressAuthCheck = ({ address, network }: { address?: stri
 export const useCosmosDelegations = ({ address, network }: { address?: string; network: Network | null }) => {
   const isCosmosNetwork = getIsCosmosNetwork(network || "");
   const castedNetwork = (isCosmosNetwork ? network : "celestia") as CosmosNetwork;
+  const shouldEnable = !!network && !!address && !!isCosmosNetwork;
 
   const { data, isLoading, error, refetch } = useQuery({
-    enabled: !!network && !!address && !!isCosmosNetwork,
+    enabled: shouldEnable,
     queryKey: ["cosmosDelegations", address, network],
-    queryFn: () => getDelegations({ apiUrl: stakingOperatorUrlByNetwork[castedNetwork], address: address || "" }),
+    queryFn: () => {
+      if (!shouldEnable) return undefined;
+      return getDelegations({ apiUrl: stakingOperatorUrlByNetwork[castedNetwork], address: address || "" });
+    },
     refetchInterval: 90000,
     refetchOnWindowFocus: true,
   });


### PR DESCRIPTION
## To reproduce the unnecessary queries issue
- On production or staging links, connect to a Cosmos chain
- Switch to Aleo
- Open a stake or unstake tx dialog, and close it by rejecting the tx
- (And reverse the order to switch from Aleo to a Cosmos chain)
- From the dev network tab, you should see the failed unnecessary queries being fired

## To review
- The unnecessary queries should go away from this PR's preview link