### PR TITLE
chore: revise Aleo explorer URL

### DIFF
--- a/app/consts.ts
+++ b/app/consts.ts
@@ -100,7 +100,7 @@ export const networkExplorer: Record<Network, string> = {
   cosmoshub: "https://www.mintscan.io/cosmos/",
   cosmoshubtestnet: "https://www.mintscan.io/cosmoshub-testnet/",
   // TODO: use dynamic Aleo network
-  aleo: "https://testnet.aleoscan.io/",
+  aleo: "https://testnetbeta.aleo123.io/",
 };
 
 export const networkExplorerTx: Record<Network, string> = {
@@ -108,7 +108,7 @@ export const networkExplorerTx: Record<Network, string> = {
   celestiatestnet3: `${networkExplorer.celestiatestnet3}tx/`,
   cosmoshub: `${networkExplorer.cosmoshub}tx/`,
   cosmoshubtestnet: `${networkExplorer.cosmoshubtestnet}tx/`,
-  aleo: `${networkExplorer.aleo}transaction?id=`,
+  aleo: `${networkExplorer.aleo}transactionDetail/`,
 };
 
 export const networkExplorerAddress: Record<Network, string> = {
@@ -116,7 +116,7 @@ export const networkExplorerAddress: Record<Network, string> = {
   celestiatestnet3: `${networkExplorer.celestiatestnet3}address/`,
   cosmoshub: `${networkExplorer.cosmoshub}address/`,
   cosmoshubtestnet: `${networkExplorer.cosmoshubtestnet}address/`,
-  aleo: `${networkExplorer.aleo}address?a=`,
+  aleo: `${networkExplorer.aleo}address/`,
 };
 
 export const CosmosNetworkVariants = ["celestia", "celestiatestnet3", "cosmoshub", "cosmoshubtestnet"] as const;


### PR DESCRIPTION
## Objective
https://testnet.aleoscan.io/ seems to be broken now. Using https://testnetbeta.aleo123.io/ as the explorer URL instead.

## To review
- Check if the tx explorer links in activity page are correct
- Check if the validator's explorer link in stake page's validator-specific view is correct