### PR TITLE
feat: liquid staked balance and cumulative rewards

### DIFF
--- a/app/(root)/_components/HeroCard/index.tsx
+++ b/app/(root)/_components/HeroCard/index.tsx
@@ -14,19 +14,21 @@ import * as S from "./heroCard.css";
 export const HeroCard = () => {
   const { connectionStatus } = useWallet();
   const { stakedBalance, isLoading: isLoadingStakedBalance, error: stakedBalanceError } = useStakedBalance() || {};
-  const { isLoading: isLoadingReward, rewards, error: rewardError } = useNetworkReward({ amount: stakedBalance }) || {};
   const { data: addressRewards } = useAddressRewards() || {};
   const { dailyRewards } = addressRewards || {};
+
+  const { isLoading: isLoadingReward, rewards, error: rewardError } = useNetworkReward({ amount: stakedBalance }) || {};
 
   const formattedStakedBalance = useDynamicAssetValueFromCoin({ coinVal: stakedBalance });
   const formattedDailyEarned = useDynamicAssetValueFromCoin({ coinVal: dailyRewards || 0 });
   const formattedEstDailyReward = useDynamicAssetValueFromCoin({ coinVal: rewards?.daily });
+
   const addressRewardsValue = useMemo(() => {
     if (!stakedBalance || stakedBalance === "0") return undefined;
     if (dailyRewards && dailyRewards !== "0") return `+Daily earned ${formattedDailyEarned}`;
     if (formattedEstDailyReward) return `Est. daily rewards ${formattedEstDailyReward}`;
     return undefined;
-  }, [addressRewards]);
+  }, [stakedBalance, dailyRewards, formattedDailyEarned, formattedEstDailyReward]);
 
   if (connectionStatus === "connected") {
     if (isLoadingStakedBalance) {
@@ -58,7 +60,7 @@ export const HeroCard = () => {
       );
     }
 
-    if (stakedBalance && stakedBalance !== "0") {
+    if (stakedBalance) {
       return (
         <CTACard
           topSubtitle={

--- a/app/(root)/_components/UnstakeNavCard/index.tsx
+++ b/app/(root)/_components/UnstakeNavCard/index.tsx
@@ -27,7 +27,6 @@ export const UnstakeNavCard = (props: NavCard.PageNavCardProps) => {
     network,
     stakingType: "liquid",
   });
-  const pAleoStakedBalanceQuery = usePAleoBalanceByAddress({ address: address || undefined, network });
 
   const fallbackTime = useFallbackTime();
   const showOneEntryOnly = aleoUnstakeStatus !== null || aleoLiquidUnstakeStatus !== null;
@@ -42,9 +41,8 @@ export const UnstakeNavCard = (props: NavCard.PageNavCardProps) => {
 
   const isDisabled = useMemo(() => {
     if (connectionStatus !== "connected") return true;
-    if (network === "aleo" && pAleoStakedBalanceQuery.stakedBalance !== "0") return false;
     return (!stakedBalance || stakedBalance === "0") && !hasPendingItems;
-  }, [connectionStatus, network, pAleoStakedBalanceQuery.stakedBalance, stakedBalance, hasPendingItems]);
+  }, [connectionStatus, stakedBalance, hasPendingItems]);
 
   const endBoxValue = useMemo(() => {
     if (connectionStatus !== "connected") return undefined;
@@ -78,18 +76,18 @@ export const UnstakeNavCard = (props: NavCard.PageNavCardProps) => {
 
       return isWithdrawable
         ? {
-            title: <NavCard.SecondaryText>Withdrawable</NavCard.SecondaryText>,
-            value: <NavCard.PrimaryText>{aleoUnbondingAmount}</NavCard.PrimaryText>,
-          }
+          title: <NavCard.SecondaryText>Withdrawable</NavCard.SecondaryText>,
+          value: <NavCard.PrimaryText>{aleoUnbondingAmount}</NavCard.PrimaryText>,
+        }
         : {
-            title: defaultTitle,
-            value: (
-              <NavCard.PrimaryText>
-                {times?.time || fallbackTime.time}{" "}
-                <NavCard.SecondaryText>{times?.unit || fallbackTime.unit} left</NavCard.SecondaryText>
-              </NavCard.PrimaryText>
-            ),
-          };
+          title: defaultTitle,
+          value: (
+            <NavCard.PrimaryText>
+              {times?.time || fallbackTime.time}{" "}
+              <NavCard.SecondaryText>{times?.unit || fallbackTime.unit} left</NavCard.SecondaryText>
+            </NavCard.PrimaryText>
+          ),
+        };
     }
   }, [
     connectionStatus,

--- a/app/(root)/rewards/_components/RewardsSummary/index.tsx
+++ b/app/(root)/rewards/_components/RewardsSummary/index.tsx
@@ -96,18 +96,18 @@ const FirstSection = () => {
 
 const SecondSection = () => {
   const { data: addressRewards, isLoading: isAddressRewardsLoading } = useAddressRewards() || {};
+
   const { stakedBalance } = useStakedBalance() || {};
-  const { rewards: networkRewards, isLoading: isNetworkRewardsLoading } =
-    useNetworkReward({ amount: stakedBalance }) || {};
+  const { rewards, isLoading: isRewardsLoading } = useNetworkReward({ amount: stakedBalance }) || {};
 
   const hasAccruedRewards = addressRewards && addressRewards.accruedRewards;
   const title = hasAccruedRewards ? "Accrued rewards" : "Est. daily rewards";
   const accruedRewards = hasAccruedRewards ? addressRewards.accruedRewards : 0;
   const isAccruedRewardsSmall =
     accruedRewards && BigNumber(accruedRewards).isLessThan(1) && BigNumber(accruedRewards).isGreaterThan(0);
-  const isLoading = hasAccruedRewards ? isAddressRewardsLoading : isNetworkRewardsLoading;
+  const isLoading = hasAccruedRewards ? isAddressRewardsLoading : isRewardsLoading;
 
-  const formattedDailyReward = useDynamicAssetValueFromCoin({ coinVal: networkRewards?.daily });
+  const formattedDailyReward = useDynamicAssetValueFromCoin({ coinVal: rewards?.daily });
   const formattedAccruedRewards = useDynamicAssetValueFromCoin({
     coinVal: accruedRewards,
     minValue: !isAccruedRewardsSmall ? undefined : 0.000001,

--- a/app/_contexts/StakingContext/hooks.tsx
+++ b/app/_contexts/StakingContext/hooks.tsx
@@ -172,9 +172,9 @@ const getDefaultInputErrorMessage = ({ amountValidation }: { amountValidation: B
 
 const useStakeMinAmount = () => {
   const { network, stakingType } = useShell();
-  const { stakedBalance } = useStakedBalance() || {};
+  const { nativeBalance } = useStakedBalance() || {};
 
-  const isInitialStake = !stakedBalance || stakedBalance === "0";
+  const isInitialStake = !nativeBalance || nativeBalance === "0";
   const minInitialAmount =
     isInitialStake && stakingType ? minInitialStakingAmountByNetwork[network || defaultNetwork][stakingType] : 0;
   const minSubsequentAmount =

--- a/app/_contexts/UnstakingContext/index.tsx
+++ b/app/_contexts/UnstakingContext/index.tsx
@@ -21,13 +21,15 @@ export const UnstakingProvider = ({ children }: T.UnstakingProviderProps) => {
   const { network, stakingType } = useShell();
   const { activeWallet, address } = useWallet();
 
-  const defaultStakedBalance = useStakedBalance();
-  const pAleoBalance = usePAleoBalanceByAddress({
+  const stakedBalanceQuery = useStakedBalance();
+  const pAleoBalanceQuery = usePAleoBalanceByAddress({
     address: address || undefined,
     network: network,
   });
   const isAleoNetwork = network && getIsAleoNetwork(network);
-  const stakedBalance = isAleoNetwork && stakingType === "liquid" ? pAleoBalance : defaultStakedBalance;
+  const stakedBalance = isAleoNetwork && stakingType === "liquid" ? pAleoBalanceQuery : stakedBalanceQuery;
+  const stakedBalanceValue =
+    isAleoNetwork && stakingType === "liquid" ? pAleoBalanceQuery?.stakedBalance : stakedBalanceQuery?.nativeBalance;
 
   const { data: cosmosSigningClient } = useCosmosSigningClient({
     network: network || defaultNetwork,
@@ -35,7 +37,7 @@ export const UnstakingProvider = ({ children }: T.UnstakingProviderProps) => {
   });
   const { amountValidation, ctaValidation } = useUnstakeAmountInputValidation({
     inputAmount: states.coinAmountInput,
-    stakedBalance: stakedBalance?.stakedBalance,
+    stakedBalance: stakedBalanceValue,
   });
   const inputErrorMessage = useUnstakeInputErrorMessage({ amountValidation, inputAmount: states.coinAmountInput });
   const { procedures, resetStates } = useTxProcedure({
@@ -58,7 +60,7 @@ export const UnstakingProvider = ({ children }: T.UnstakingProviderProps) => {
         procedures,
         amountInputPad,
         stakedBalance: {
-          data: stakedBalance?.stakedBalance,
+          data: stakedBalanceValue,
           isLoading: stakedBalance?.isLoading || false,
           error: stakedBalance?.error || null,
         },

--- a/app/_services/aleo/pondo/hooks.tsx
+++ b/app/_services/aleo/pondo/hooks.tsx
@@ -6,13 +6,13 @@ import { useShell } from "@/app/_contexts/ShellContext";
 import { getIsAleoNetwork } from "../utils";
 
 export const usePondoData = () => {
-  const { network, stakingType } = useShell();
+  const { network } = useShell();
   const isAleoNetwork = getIsAleoNetwork(network || "");
-  const shouldEnable = isAleoNetwork && stakingType === "liquid";
+  const shouldEnable = isAleoNetwork;
 
   const { data, isLoading, refetch } = useQuery({
     enabled: shouldEnable,
-    queryKey: ["pondoData"],
+    queryKey: ["pondoData", shouldEnable],
     queryFn: () => {
       if (!shouldEnable) return null;
       return getPondoData({ apiUrl: networkEndpoints.aleo.rpc });
@@ -29,6 +29,7 @@ export const usePondoData = () => {
   const aleoToPAleoRate = 1 / pAleoToAleoRate;
 
   return {
+    data,
     pAleoToAleoRate,
     aleoToPAleoRate,
     isLoading,

--- a/app/_services/aleo/pondo/index.ts
+++ b/app/_services/aleo/pondo/index.ts
@@ -1,6 +1,6 @@
 import { fetchData } from "@/app/_utils/fetch";
 
-export const getPondoData = async ({ apiUrl }: { apiUrl: string }) => {
+export const getPondoData = async ({ apiUrl }: { apiUrl: string }): Promise<PondoDataResult> => {
   const res = await fetchData(`${apiUrl}`, {
     method: "POST",
     headers: {
@@ -13,4 +13,17 @@ export const getPondoData = async ({ apiUrl }: { apiUrl: string }) => {
     }),
   });
   return res.result;
+};
+
+type PondoDataResult = {
+  protocolBalance: string;
+  totalCredits: string;
+  pondoTVL: string;
+  bondedWithdrawals: string;
+  lastDelegatedBalance: string;
+  reservedForWithdrawals: string;
+  protocolState: string;
+  mintedPaleo: string;
+  paleoSupply: string;
+  pondoSupply: string;
 };

--- a/app/_services/stakingOperator/aleo/index.ts
+++ b/app/_services/stakingOperator/aleo/index.ts
@@ -40,6 +40,13 @@ export const getAddressStakedBalance = async ({ apiUrl, address }: T.BaseParams)
   return res;
 };
 
+export const getAddressHistoricalStakingAmount = async ({ apiUrl, address }: T.BaseParams) => {
+  const res: T.AddressHistoricalStakingAmountResponse = await fetchData(
+    `${apiUrl}address/${address}/historical-staking-amount`,
+  );
+  return res;
+};
+
 export const getAddressDelegation = async ({ apiUrl, address }: T.BaseParams) => {
   const res: T.ValidatorDetailsResponse = await fetchData(`${apiUrl}address/${address}/delegation`);
   return res.response;

--- a/app/_services/stakingOperator/hooks.tsx
+++ b/app/_services/stakingOperator/hooks.tsx
@@ -84,10 +84,10 @@ export const useStakedBalance = () => {
   switch (network) {
     case "celestia":
     case "celestiatestnet3":
-      return celestiaData;
+      return { ...celestiaData, nativeBalance: undefined, liquidBalance: undefined };
     case "cosmoshub":
     case "cosmoshubtestnet":
-      return cosmoshubData;
+      return { ...cosmoshubData, nativeBalance: undefined, liquidBalance: undefined };
     case "aleo":
       return aleoData;
     default:

--- a/app/_services/stakingOperator/types.ts
+++ b/app/_services/stakingOperator/types.ts
@@ -366,6 +366,19 @@ export type AddressStakedBalanceResponse = {
   "total-staked"?: number;
 };
 
+export type AddressHistoricalStakingAmountResponse = {
+  historicalAmount: {
+    aleo: {
+      stake: number;
+      unstake: number;
+    };
+    pondo_v1: {
+      stake: number;
+      unstake: number;
+    };
+  };
+};
+
 export type PaginationParams = {
   offset: number;
   limit: number;


### PR DESCRIPTION
## To review
- **On home page, verify "Total staked balance" value is correct**
  - The value should be the sum of your current native and liquid stake amounts.
- **On rewards page, verify "Cumulative rewards" value is correct**
  - The value should be the sum of your native rewards (from the [staking operator endpoint](https://test-aleo-staking-api.staking.xyz/swagger/index.html#/Address/get_v1_address__address__rewards)) and the liquid rewards (calculated with this formula `current_paleo_balance * (pondoTVL / paleoSupply) - historical_liquid_staked_amounts + historical_liquid_unstaked_amounts`)
  - ⚠️ If you see negative rewards value, it's EXPECTED if you've ever done liquid stake BEFORE PR #452 was created. It's because the minted value calculated on the FE wasn't correct before that PR.