### PR TITLE
chore: implement pondo fees from snarkos

### DIFF
--- a/app/consts.ts
+++ b/app/consts.ts
@@ -293,11 +293,11 @@ export const aleoDefaultClaimFee = "88711";
 export const aleoFees = {
   stake: {
     native: "182079",
-    liquid: "669023",
+    liquid: "477543",
   },
   unstake: {
     native: "365356",
-    liquid: "556319",
+    liquid: "532935",
   },
   instant_unstake: {
     native: null,
@@ -313,7 +313,7 @@ export const aleoFees = {
   },
   withdraw: {
     native: "88711",
-    liquid: "175655",
+    liquid: "126015",
   },
 };
 


### PR DESCRIPTION
## Note
With these new fees, these are the tx outcomes:
- ~~[deposit_public_as_signer](https://testnet.aleoscan.io/transaction?id=at1upzazd8v7vn7vf2acfku6algxnvyu2zyndxleugewn76l6ce8sqqg7mnqa) - `rejected`~~
- [instant_withdraw_public](https://testnet.aleoscan.io/transaction?id=at1aeplpap0tgujznv8gy8wd8wssgc5gpu2uwprfe49fe2n8xtxlgrsm8alkt) - `accepted`
- [withdraw_public](https://testnet.aleoscan.io/transaction?id=at1k7jt42q3gylld0ghn5xmyk6gelz884nc0zfxa7jpg8dfkcxtaczs4g673n) - `accepted`
- claim_withdrawal_public (I don't have a withdrawable amount yet; 2 days left. @vince19972 @eddy-apybara @ziggahunhow can you help test this and drop the tx link?)

## Updated
- [deposit_public_as_signer](https://testnet.aleoscan.io/transaction?id=at1myffse7cqujatjww95w6cqgm3t7aplz942wx4zj4wxnhk7l55v8qr6vh56) - `accepted`