### PR TITLE
style: fix input pad availability element render

### DIFF
--- a/app/_components/AmountInputPad/index.tsx
+++ b/app/_components/AmountInputPad/index.tsx
@@ -120,21 +120,23 @@ export const AmountInputPad = ({
       type={type}
       availableValue={availableValue}
       availabilityElement={
-        <AvailabilityElement
-          type={type}
-          availableValue={availableValue}
-          primaryCurrency={primaryCurrency}
-          tooltip={
-            type === "unstake" &&
-            !isAleo && (
-              <Tooltip
-                className={S.topBarTooltip}
-                trigger={<Icon name="info" />}
-                content="You can only unstake positions that have been staked through Staking.xyz."
-              />
-            )
-          }
-        />
+        availableValue ? (
+          <AvailabilityElement
+            type={type}
+            availableValue={availableValue}
+            primaryCurrency={primaryCurrency}
+            tooltip={
+              type === "unstake" &&
+              !isAleo && (
+                <Tooltip
+                  className={S.topBarTooltip}
+                  trigger={<Icon name="info" />}
+                  content="You can only unstake positions that have been staked through Staking.xyz."
+                />
+              )
+            }
+          />
+        ) : null
       }
       isAvailableValueLoading={isAvailableValueLoading}
       inputField={{


### PR DESCRIPTION
## Description
For now, the input pad has an extra top margin on stake page when wallet is disconnected.

![Screenshot 2024-09-24 at 2 33 15 PM](https://github.com/user-attachments/assets/d7c4f863-cc1e-4e2f-8ad3-5971fd941148)

## Changes
Only render the `AvailabilityElement` component when `availableValue` is valid
