### PR TITLE
chore: avoid Aleo tx dialog success state

### DIFF
--- a/app/(root)/_components/TxProcedureDialog.tsx
+++ b/app/(root)/_components/TxProcedureDialog.tsx
@@ -65,6 +65,14 @@ export const TxProcedureDialog = ({
     }
   }, [connectionStatus, open, inputState]);
 
+  // If Aleo, reset the procedures state to default after active,
+  // because Aleo uses SendingTransactionsCapsule and SendingTransactionsDialog,
+  useEffect(() => {
+    if (network === "aleo" && procedures?.[0]?.state === "success") {
+      resetProceduresStates();
+    }
+  }, [network, procedures?.[0]?.state]);
+
   useTxPostHogEvents({
     type: type === "withdraw" ? "claim" : type,
     open,


### PR DESCRIPTION
## To review
1. Locally, make sure to uncomment the `SendingTransactionsCapsule` component in `WidgetShell`
2. Send an Aleo stake tx
3. Before the tx succeeds, click "Stake" again, and the tx dialog should be default state with "Confirm" CTA
4. Once the tx is successful, click "Stake" again, and the tx dialog should be default state with "Confirm" CTA