### PR TITLE
feat: integrate Aleo RPC getTokenOwnerHash

### DIFF
--- a/app/_services/aleo/hooks.tsx
+++ b/app/_services/aleo/hooks.tsx
@@ -12,9 +12,8 @@ import { useWallet as useLeoWallet } from "@demox-labs/aleo-wallet-adapter-react
 import {
   stakingOperatorUrlByNetwork,
   ALEO_PONDO_CORE_ID,
-  ALEO_PONDO_TOKEN_ID,
-  ALEO_PONDO_TOKEN_NETWORK,
   ALEO_MTSP_ID,
+  ALEO_PONDO_TOKEN_ID,
   defaultNetwork,
   isAleoTestnet,
 } from "../../consts";
@@ -171,7 +170,6 @@ export const usePAleoBalanceByAddress = ({ address, network }: { address?: strin
         apiUrl: networkEndpoints.aleo.rpc,
         address: address || "",
         tokenId: ALEO_PONDO_TOKEN_ID,
-        tokenIdNetwork: ALEO_PONDO_TOKEN_NETWORK,
         mtspProgramId: ALEO_MTSP_ID,
       });
     },

--- a/app/_services/aleo/sdk/utils.ts
+++ b/app/_services/aleo/sdk/utils.ts
@@ -1,12 +1,3 @@
-export const getLazyInitAleoSDK = async () => {
-  try {
-    return await import("@demox-labs/aleo-sdk");
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
-};
-
 /**
  * Aleo uses funky serialization for its JSON objects. This function takes that funky representation
  * and makes it a valid json object

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky",
-    "type-check": "tsc -p tsconfig.json --noEmit --incremental false",
-    "postinstall": "sed -ibak 's/await initializeWorker(Cargo);/(async () => await initializeWorker(Cargo))();/' node_modules/@demox-labs/aleo-sdk/dist/worker.js"
+    "type-check": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cosmjs/amino": "^0.32.3",
@@ -27,7 +26,6 @@
     "@cosmos-kit/okxwallet": "^2.7.0",
     "@cosmos-kit/react": "^2.13.0",
     "@cosmos-kit/react-lite": "^2.9.0",
-    "@demox-labs/aleo-sdk": "^0.3.39",
     "@demox-labs/aleo-wallet-adapter-base": "^0.0.22",
     "@demox-labs/aleo-wallet-adapter-leo": "^0.0.24",
     "@demox-labs/aleo-wallet-adapter-react": "^0.0.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,6 @@ importers:
       "@cosmos-kit/react-lite":
         specifier: ^2.9.0
         version: 2.9.0(@cosmjs/amino@0.32.3)(@cosmjs/proto-signing@0.32.3)(@types/react-dom@18.2.21)(@types/react@18.2.65)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(utf-8-validate@5.0.10)
-      "@demox-labs/aleo-sdk":
-        specifier: ^0.3.39
-        version: 0.3.39
       "@demox-labs/aleo-wallet-adapter-base":
         specifier: ^0.0.22
         version: 0.0.22
@@ -616,10 +613,6 @@ packages:
     peerDependencies:
       "@cosmjs/amino": ">= ^0.32"
       "@cosmjs/proto-signing": ">= ^0.32"
-
-  "@demox-labs/aleo-sdk@0.3.39":
-    resolution:
-      { integrity: sha512-+R20JpeikTHpP1OmQqkCsjBmMHgTKu6l1T3zlaw3OMK8E3tslOufUoi9vHMweAQtBKjsx2/d0XfVZttBdbL5bA== }
 
   "@demox-labs/aleo-wallet-adapter-base@0.0.21":
     resolution:
@@ -7994,8 +7987,6 @@ snapshots:
       "@cosmjs/amino": 0.32.3
       "@cosmjs/proto-signing": 0.32.3
       uuid: 9.0.1
-
-  "@demox-labs/aleo-sdk@0.3.39": {}
 
   "@demox-labs/aleo-wallet-adapter-base@0.0.21":
     dependencies:


### PR DESCRIPTION
## To review
- Connect to the preview link on Leo Wallet TestFlight mobile app, you should see correct total staked balance on home page, and pALEO balance in unstake page.
- Connect to the preview link on desktop to confirm everything's working as well

## Changes
- Remove `@demox-labs/aleo-sdk` package
- Use new `getTokenOwnerHash` mapping from Aleo RPC endpoint to fetch pALEO token owner hash