### PR TITLE
style: revise withdrawal CTA color

### DIFF
--- a/app/(root)/unstake/_components/UnstakeInfoBox.tsx
+++ b/app/(root)/unstake/_components/UnstakeInfoBox.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useMemo } from "react";
+import { Arrow } from "@radix-ui/react-tooltip";
 import cn from "classnames";
 import BigNumber from "bignumber.js";
 import { useShell } from "../../../_contexts/ShellContext";
@@ -63,9 +64,12 @@ const AleoUnstakeInfo = () => {
             </button>
           }
           content={
-            isLiquid
-              ? `You need to withdraw before making a new unstaking request.`
-              : `You can withdraw ${aleoUnbondingAmount} now!`
+            <>
+              {isLiquid
+                ? `You need to withdraw before making a new unstaking request.`
+                : `You can withdraw ${aleoUnbondingAmount} now!`}
+              <Arrow className={S.withdrawTooltipArrow} />
+            </>
           }
         />
       );

--- a/app/(root)/unstake/_components/unstake.css.ts
+++ b/app/(root)/unstake/_components/unstake.css.ts
@@ -57,22 +57,27 @@ export const claimableStatus = style({
 });
 
 export const withdrawableTooltip = style({
-  maxInlineSize: pxToRem(246),
+  maxInlineSize: pxToRem(148),
   padding: pxToRem(16),
-  backgroundColor: colors.yellow100,
+  backgroundColor: colors.green100,
   border: 0,
-  color: colors.yellow900,
+  color: colors.green900,
   textAlign: "center",
+  borderRadius: pxToRem(8),
 });
 
 export const withdrawButton = style({
-  backgroundColor: colors.yellow100,
+  backgroundColor: colors.green100,
   border: 0,
-  borderRadius: pxToRem(4),
-  color: colors.yellow900,
+  borderRadius: pxToRem(8),
+  color: colors.green900,
   blockSize: pxToRem(20),
-  paddingInline: pxToRem(6),
+  paddingInline: pxToRem(8),
   fontSize: pxToRem(12),
   lineHeight: 1,
   fontWeight: weights.bold,
+});
+
+export const withdrawTooltipArrow = style({
+  fill: colors.green100,
 });


### PR DESCRIPTION
## To review
If you don't have any withdrawal credits at the moment, this is a demo of the revised color on FE (ignore the empty withdrawable value in the box).

![Screenshot 2024-10-01 at 11 59 41 AM](https://github.com/user-attachments/assets/9c8d6aa9-6274-4e41-8523-bcd4c70df74d)

