### PR TITLE
chore: integrate Pondo-specific Aleo network reward

### DIFF
--- a/app/(root)/stake/_components/StakeInfoBox.tsx
+++ b/app/(root)/stake/_components/StakeInfoBox.tsx
@@ -19,11 +19,13 @@ import {
 import { usePondoData } from "@/app/_services/aleo/pondo/hooks";
 
 import * as S from "./stake.css";
+import { useAleoPondoReward } from "@/app/_services/stakingOperator/aleo/hooks";
 
 export const StakeInfoBox = () => {
   const { network, stakingType } = useShell();
   const { coinAmountInput } = useStaking();
   const networkReward = useNetworkReward({ amount: coinAmountInput });
+  const pondoNetworkReward = useAleoPondoReward({ network, amount: coinAmountInput || "0" });
   const { validatorDetails } = useStakeValidatorState();
   const { aleoToPAleoRate } = usePondoData() || {};
 
@@ -36,6 +38,13 @@ export const StakeInfoBox = () => {
   const aleoTxFee = useDynamicAssetValueFromCoin({
     coinVal: getMicroCreditsToCredits(aleoFees.stake[stakingType || "native"]),
   });
+
+  const networkRewardRate = useMemo(() => {
+    if (isAleo && isLiquid) {
+      return pondoNetworkReward?.rewards.percentage || 0;
+    }
+    return networkReward?.rewards.percentage || 0;
+  }, [networkReward, pondoNetworkReward, isAleo, isLiquid]);
 
   const fixedAleoToPAleoAmount = useMemo(() => {
     const val = getPAleoDepositMintingAmountFromAleo({
@@ -71,7 +80,7 @@ export const StakeInfoBox = () => {
             <InfoCard.Title>Est. reward rate</InfoCard.Title>
             {hasInput && <RewardsTooltip amount={coinAmountInput} />}
           </InfoCard.TitleBox>
-          <InfoCard.Content className={S.rewardInfoValue}>{networkReward?.rewards.percentage}%</InfoCard.Content>
+          <InfoCard.Content className={S.rewardInfoValue}>{networkRewardRate}%</InfoCard.Content>
         </InfoCard.StackItem>
         {hasInput && isAleo && (
           <InfoCard.StackItem>

--- a/app/_services/stakingOperator/aleo/hooks.tsx
+++ b/app/_services/stakingOperator/aleo/hooks.tsx
@@ -15,6 +15,7 @@ import {
   getAddressDelegation,
   getAddressHistoricalStakingAmount,
   getNetworkReward,
+  getPondoNetworkReward,
   getNetworkStatus,
   getServerStatus,
   getValidatorDetails,
@@ -26,7 +27,7 @@ import { fromUnixTime } from "date-fns";
 import { useShell } from "@/app/_contexts/ShellContext";
 import { getAleoFromPAleo } from "../../aleo/utils";
 import { usePondoData } from "@/app/_services/aleo/pondo/hooks";
-import { useAleoNativeStakedBalanceByAddress, usePAleoBalanceByAddress } from "@/app/_services/aleo/hooks";
+import { usePAleoBalanceByAddress } from "@/app/_services/aleo/hooks";
 
 export const useAleoAddressRewards = ({ address, network }: { address: string; network: Network | null }) => {
   const shouldEnable = getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address);
@@ -255,6 +256,20 @@ export const useAleoReward = ({ network, amount }: { network: Network | null; am
     enabled: getIsAleoNetwork(network || ""),
     queryKey: ["aleoReward", network],
     queryFn: () => getNetworkReward({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"] }),
+    refetchOnWindowFocus: true,
+    refetchInterval: 600000, // 10 minutes
+  });
+
+  const rewards = getCalculatedRewards(amount, data || 0);
+
+  return { data, rewards, isLoading, isRefetching, error, refetch };
+};
+
+export const useAleoPondoReward = ({ network, amount }: { network: Network | null; amount: string }) => {
+  const { data, isLoading, isRefetching, error, refetch } = useQuery({
+    enabled: getIsAleoNetwork(network || ""),
+    queryKey: ["aleoPondoReward", network],
+    queryFn: () => getPondoNetworkReward({ apiUrl: stakingOperatorUrlByNetwork[network || "aleo"] }),
     refetchOnWindowFocus: true,
     refetchInterval: 600000, // 10 minutes
   });

--- a/app/_services/stakingOperator/aleo/index.ts
+++ b/app/_services/stakingOperator/aleo/index.ts
@@ -102,6 +102,11 @@ export const getNetworkReward = async ({ apiUrl }: Omit<T.BaseParams, "address">
   return res;
 };
 
+export const getPondoNetworkReward = async ({ apiUrl }: Omit<T.BaseParams, "address">) => {
+  const res: T.NetworkRewardResponse = await fetchData(`${apiUrl}network/reward/pondo_v1`);
+  return res;
+};
+
 export const setMonitorTxByAddress = async ({
   apiUrl,
   address,


### PR DESCRIPTION
## To review
- Go to stake page
- Click on liquid and native type, the network reward rates should be different