### PR TITLE
strip out just u64 from microcredits string in result

### DIFF
--- a/app/_services/aleo/sdk/index.ts
+++ b/app/_services/aleo/sdk/index.ts
@@ -51,7 +51,7 @@ export const getAleoNativeStakedBalanceByAddress = async ({ apiUrl, address }: {
     return "0";
   }
 
-  return BigNumber(JSON.parse(getFormattedAleoString(res.result))["microcredits"].slice(0, -4)).toString();
+  return BigNumber(JSON.parse(getFormattedAleoString(res.result))["microcredits"].slice(0, -3)).toString();
 };
 
 export const getPAleoBalanceByAddress = async ({


### PR DESCRIPTION
## Changes
If the result from the RPC endpoint is in the below format, I suppose the aim is to strip out just `u64` from the microcredits field
```
"{\n  validator: aleo1qc46ca98xxjy34v37ge75yydyt36mgatqup7zrjra6gp9huatsqsjv6p52,\n  microcredits: 10000243051u64\n}"
```

In that case, the splice value should be `-3`, not `-4`