### PR TITLE
fix: negative cumulative rewards

### DIFF
--- a/app/_services/stakingOperator/aleo/hooks.tsx
+++ b/app/_services/stakingOperator/aleo/hooks.tsx
@@ -52,13 +52,13 @@ export const useAleoAddressRewards = ({ address, network }: { address: string; n
   });
 
   const nativeCumulativeRewards = stakingOperatorData?.cumulativeRewards || 0;
-  const liquidCumulativeRewards =
-    pAleoMicroBalance && pAleoToAleoRate
-      ? BigNumber(getAleoFromPAleo(pAleoMicroBalance, pAleoToAleoRate))
-          .minus(historicalStakingAmount.data?.historicalAmount.pondo_v1.stake || 0)
-          .plus(historicalStakingAmount.data?.historicalAmount.pondo_v1.unstake || 0)
-          .toNumber()
-      : 0;
+  const hasPAleoBalance = pAleoMicroBalance && pAleoMicroBalance !== "0" && pAleoToAleoRate;
+  const liquidCumulativeRewards = hasPAleoBalance
+    ? BigNumber(getAleoFromPAleo(pAleoMicroBalance, pAleoToAleoRate))
+        .minus(historicalStakingAmount.data?.historicalAmount.pondo_v1.stake || 0)
+        .plus(historicalStakingAmount.data?.historicalAmount.pondo_v1.unstake || 0)
+        .toNumber()
+    : 0;
   const cumulativeMicroRewards = BigNumber(nativeCumulativeRewards).plus(liquidCumulativeRewards).toNumber();
 
   return {


### PR DESCRIPTION
## Objective
Ignore pALEO rewards when its value is "0" to avoid negative calculation.

## To review
This is a screenshot of the user's address on my local machine.
<img width="428" alt="Screenshot 2024-10-07 at 6 50 00 AM" src="https://github.com/user-attachments/assets/ec926bf7-ecea-48f9-a9bb-dcaf8f9c9172">
