### PR TITLE
fix: client-side redirect rerendering bug

### DIFF
--- a/app/_contexts/WidgetContext/hooks.tsx
+++ b/app/_contexts/WidgetContext/hooks.tsx
@@ -16,25 +16,26 @@ export const useWidgetRouterGate = ({ status, setStates }: WidgetStates) => {
   const { isOnMobileDevice } = useShell();
   const searchParams = useSearchParams();
 
+  // Redirect to the stake page on initial visit
   useEffect(() => {
-    // Redirect to the stake page on initial visit
-    if (connectionStatus === "disconnected" && pathname === "/" && status === "loading") {
+    if (pathname === "/" && status === "loading") {
       router.push(stakePageLink);
       return;
     }
 
-    // Redirect to the home page if the user is not connected and the page is the activity or rewards page
+    setStates({ status: "loaded" });
+  }, [pathname, status]);
+
+  // Redirect to the home page if the user is not connected and the page is the activity or rewards page
+  useEffect(() => {
     if (
       connectionStatus === "disconnected" &&
       status !== "loading" &&
       ["/activity", "/rewards", "rewards/history"].includes(pathname)
     ) {
       router.push(homePageLink);
-      return;
     }
-
-    setStates({ status: "loaded" });
-  }, [pathname, connectionStatus, status]);
+  }, [pathname, connectionStatus]);
 
   // Redirect to the default network if the current network is disabled on mobile
   useEffect(() => {

--- a/app/_services/aleo/leoWallet/hooks.tsx
+++ b/app/_services/aleo/leoWallet/hooks.tsx
@@ -123,7 +123,6 @@ export const useLeoWalletStates = () => {
 
 export const useLeoWalletConnector = () => {
   const { select } = useLeoWallet();
-  useLeoWalletLocalStorageHack();
 
   return async () => {
     await select("Leo Wallet" as WalletName);
@@ -177,15 +176,4 @@ export const useIsLeoWalletInstalled = () => {
 export const useLeoWalletHasStoredConnection = () => {
   const [leoWalletName] = useLocalStorage<string | undefined>("walletName", undefined);
   return leoWalletName === "Leo Wallet";
-};
-
-// This hack is necessary to avoid various Leo Wallet bugs caused by the wallet name being stored in local storage.
-const useLeoWalletLocalStorageHack = () => {
-  const { wallet } = useLeoWallet();
-
-  useEffect(() => {
-    if (wallet) {
-      localStorage.removeItem("walletName");
-    }
-  }, [wallet]);
 };


### PR DESCRIPTION
## Objective
Resolve the client-side error caused by the client-side redirecting procedures.

![IMG_0227](https://github.com/user-attachments/assets/50558624-e2d6-44f5-9f9a-b0c8ca6182d3)

## To review
### 1. On both **desktop** and **Leo Wallet app browser**, repeatedly do these actions:
- Connect to wallet with mainnet selected in Leo Wallet
- Close the preview link, switch to testnet in Leo Wallet
- Reopen the preview link, and you should not see a client-side error

### 2. Poke around with other networks (on desktop only) and pages:
- Try Celestia and CosmosHub to ensure everything works (on desktop only)
- Try behaviors like connect to wallet, visit activity page, and disconnect

Overall, this PR shouldn't make other changes than fixing the client-side error.

## Changes
- For the initial home page to stake page redirect procedure, remove the wallet's `connectionStatus` dependency