### PR TITLE
feat: Aleo address rewards lastIndexed time

### DIFF
--- a/app/_services/stakingOperator/aleo/hooks.tsx
+++ b/app/_services/stakingOperator/aleo/hooks.tsx
@@ -22,11 +22,11 @@ import {
 import { useEffect, useState } from "react";
 import { getCalculatedRewards, getLastOffset } from "../utils";
 import { getTimeDiffInSingleUnits } from "@/app/_utils/time";
-import { fromUnixTime } from "date-fns";
+import { fromUnixTime, format } from "date-fns";
 import { useShell } from "@/app/_contexts/ShellContext";
 import { getAleoFromPAleo } from "../../aleo/utils";
 import { usePondoData } from "@/app/_services/aleo/pondo/hooks";
-import { useAleoNativeStakedBalanceByAddress, usePAleoBalanceByAddress } from "@/app/_services/aleo/hooks";
+import { usePAleoBalanceByAddress } from "@/app/_services/aleo/hooks";
 
 export const useAleoAddressRewards = ({ address, network }: { address: string; network: Network | null }) => {
   const shouldEnable = getIsAleoNetwork(network || "") && getIsAleoAddressFormat(address);
@@ -67,6 +67,7 @@ export const useAleoAddressRewards = ({ address, network }: { address: string; n
       dailyRewards: null,
       accruedRewards: null,
       lastCycleRewards: null,
+      lastNativeRewardsIndexedTime: format(fromUnixTime(stakingOperatorData?.lastIndexed || 0), "yyyy-MM-dd HH:mm:ss"),
     },
     isLoading,
     isRefetching,

--- a/app/_services/stakingOperator/cosmos/hooks.tsx
+++ b/app/_services/stakingOperator/cosmos/hooks.tsx
@@ -221,6 +221,7 @@ export const useCosmosAddressRewards = ({ network, address }: { network: Network
       }),
       dailyRewards: getCoinValueFromDenom({ network: castedNetwork, amount: data?.data?.daily_rewards }),
       accruedRewards: getCoinValueFromDenom({ network: castedNetwork, amount: data?.data?.accrued_rewards }),
+      lastNativeRewardsIndexedTime: null,
     },
     refetch,
   };

--- a/app/_services/stakingOperator/types.ts
+++ b/app/_services/stakingOperator/types.ts
@@ -334,6 +334,7 @@ export type AddressRewardsResponse = CommonResponse<
 
 export type AleoAddressRewardsResponse = {
   cumulativeRewards: number;
+  lastIndexed: number;
 };
 
 export type AddressRewardsHistoryResponse = CommonEntriesResponse<


### PR DESCRIPTION
## To review
- Connect to an address with staked balance, you should see "Cumulative rewards" tooltip "Sum of all staking rewards earned on this address. Calculated at XX:XX UTC. Updates every 5 mins."
- It might be a bit hard to review an address with `0` cumulative rewards. So here's a screenshot from my local machine:
<img width="425" alt="Screenshot 2024-10-09 at 10 36 41 AM" src="https://github.com/user-attachments/assets/3cf2d80d-5bba-4951-aaa8-ec0c788a9b5a">

## Notes
- I remove the "on this address" texts from the copy to make the line shorter.