### PR TITLE
build: integrate Dependabot to bump packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Always increase the version requirement
+    # to match the new version.
+    versioning-strategy: increase

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "engines": {
     "node": ">=18",
-    "pnpm": ">=3"
-  }
+    "pnpm": ">=9"
+  },
+  "packageManager": "pnpm@9.3.0"
 }


### PR DESCRIPTION
## Objective
Integrate [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) to keep packages versions up-to-date.

The integration should results in automatic PRs to bump package versions when available. 

## Notes
- I hope the configs work correctly after merging to `staging`. But if it doesn't, this doesn't any of our code. We just need to keep pushing changes to correct the configs.
- Specify `versioning-strategy` to `increase` to ensure `package.json` and `package-lock.json` are both written to with a version increase (https://stackoverflow.com/questions/60201543/dependabot-only-updates-lock-file).
- Specify `pacakgeManager` field in `package.json` to ensure correct `pnpm-lock` file version (https://github.com/dependabot/dependabot-core/issues/9684#issuecomment-2171818307).