### PR TITLE
feat: validate Coinbase Quest userId format

### DIFF
--- a/app/_components/QuestWarningBannerAndDialog/index.tsx
+++ b/app/_components/QuestWarningBannerAndDialog/index.tsx
@@ -4,6 +4,7 @@ import { useShell } from "@/app/_contexts/ShellContext";
 import { Icon } from "@/app/_components/Icon";
 import * as Dialog from "../Dialog";
 import { CTAButton, LinkCTAButton } from "../CTAButton";
+import { getIsUserIdValid } from "@/app/_utils/aleoQuest";
 import * as S from "./questWarningBannerAndDialog.css";
 
 export const QuestWarningBannerAndDialog = () => {
@@ -11,8 +12,9 @@ export const QuestWarningBannerAndDialog = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const userId = searchParams.get("userId");
+  const isUserIdValid = getIsUserIdValid(userId || undefined);
 
-  const shouldShowBanner = pathname === "/stake" && network === "aleo" && !!isOnMobileDevice && !userId;
+  const shouldShowBanner = pathname === "/stake" && network === "aleo" && !!isOnMobileDevice && !isUserIdValid;
   if (!shouldShowBanner) return null;
 
   return (

--- a/app/_services/aleo/hooks.tsx
+++ b/app/_services/aleo/hooks.tsx
@@ -57,6 +57,7 @@ import { useShell } from "@/app/_contexts/ShellContext";
 import { usePondoData } from "./pondo/hooks";
 import { useDialog } from "@/app/_contexts/UIContext";
 import { useSendingTransactions } from "@/app/_components/SendingTransactionsDialog";
+import { getIsUserIdValid } from "@/app/_utils/aleoQuest";
 
 const defaultChainId = isAleoTestnet ? "testnet" : "mainnet";
 
@@ -364,7 +365,7 @@ const useAleoBroadcastTx = ({
       ];
 
       // Coinbase Quest user tracking
-      if (isAleoOnlyInstance && uuidParam) {
+      if (isAleoOnlyInstance && uuidParam && getIsUserIdValid(uuidParam)) {
         setCoinbaseUserTracking({
           apiUrl: stakingOperatorUrlByNetwork[network || "aleo"],
           address: address || "",

--- a/app/_utils/aleoQuest.ts
+++ b/app/_utils/aleoQuest.ts
@@ -1,0 +1,4 @@
+export const getIsUserIdValid = (userId?: string) => {
+  if (!userId) return false;
+  return userId.length === 72 && userId.endsWith("t7kgaqlm");
+};


### PR DESCRIPTION
## Descriptions
- Validates the `userId` param string against the following conditions
  - Length: is it 72 chars
  - Ending: does it end with "t7kgaqlm"

## To review
- Open the preview link on mobile device
- Go to stake page
- If you add an invalid `userId` param, you should see the warning banner
   - E.g. `testing-123-abc`
   - E.g. `234567890123456789012345678901234567890123456789012345678901234t7kgaqlm` (only 71 chars, though ending with "t7kgaqlm")
  - E.g. `1234567890123456789012345678901234567890123456789012345678901234t7kgaqlx` (72 chars, not ending with "t7kgaqlm")
- If you add a valid `userId` param, you should not see the warning banner
  - E.g. `1234567890123456789012345678901234567890123456789012345678901234t7kgaqlm`