### PR TITLE
fix: decimal splitting bug

### DIFF
--- a/app/_utils/number.ts
+++ b/app/_utils/number.ts
@@ -15,7 +15,7 @@ export const getDoesNumberHasDecimals = (val: number) => {
 
 export const getDecimalCounts = (val: number) => {
   if (!getDoesNumberHasDecimals(val)) return 0;
-  return val.toString().split(".")[1].length;
+  return val.toString()?.split(".")?.[1]?.length || 0;
 };
 
 export const getFormattedMantissa = ({ val, maxMantissa }: { val?: number | string; maxMantissa?: number }) => {


### PR DESCRIPTION
## Objective
Fixes the decimal number formatting bug. For example - https://sentry.staking.xyz/share/issue/b7ada9e1f061401cb237fe897da1ab1b/.

## To review
- On the current production site, if you put super long decimals like `0.0000000000001`, and start deleting `0`s one by one, you'd experience the bug.
- On this preview link, doing the same thing shouldn't cause any problems.